### PR TITLE
fix: add `$ORIGIN` to load path on linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-rpath,$ORIGIN"]


### PR DESCRIPTION
This fixes #44.

This fixes the issue that the `libgdcef.so` loads `libcef.so`. When `libcef.so` loads all the other dylibs, it should be automatically done since the prebuilt Linux distro of CEF frameworks does this automatically. See https://github.com/chromiumembedded/cef/blob/2841752148842b6ce800c1827804d0a6ef960ff5/bazel/linux/fix_rpath.bzl#L20