### PR TITLE
fix: fix audio stream close error

### DIFF
--- a/crates/gdcef/src/browser.rs
+++ b/crates/gdcef/src/browser.rs
@@ -7,6 +7,7 @@ use cef_app::{CursorType, FrameBuffer, PhysicalSize, PopupState};
 use godot::classes::{ImageTexture, Texture2Drd};
 use godot::prelude::*;
 use std::collections::VecDeque;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
@@ -150,6 +151,9 @@ pub struct DownloadUpdateEvent {
 pub type DownloadRequestQueue = Arc<Mutex<VecDeque<DownloadRequestEvent>>>;
 pub type DownloadUpdateQueue = Arc<Mutex<VecDeque<DownloadUpdateEvent>>>;
 
+/// Shutdown flag for audio handler to suppress errors during cleanup.
+pub type AudioShutdownFlag = Arc<AtomicBool>;
+
 #[derive(Debug, Clone, Default)]
 pub struct DragState {
     pub is_drag_over: bool,
@@ -227,4 +231,6 @@ pub struct App {
     pub audio_sample_rate: Option<AudioSampleRateState>,
     pub download_request_queue: Option<DownloadRequestQueue>,
     pub download_update_queue: Option<DownloadUpdateQueue>,
+    /// Shutdown flag for audio handler to suppress errors during cleanup.
+    pub audio_shutdown_flag: Option<AudioShutdownFlag>,
 }

--- a/crates/gdcef/src/cef_texture/browser_lifecycle.rs
+++ b/crates/gdcef/src/cef_texture/browser_lifecycle.rs
@@ -23,6 +23,12 @@ impl CefTexture {
             return;
         }
 
+        // Signal audio handler that we're shutting down to suppress "socket closed" errors
+        if let Some(ref shutdown_flag) = self.app.audio_shutdown_flag {
+            use std::sync::atomic::Ordering;
+            shutdown_flag.store(true, Ordering::Relaxed);
+        }
+
         // Hide the TextureRect and clear its texture BEFORE freeing resources.
         // This prevents Godot from trying to render with an invalid texture during shutdown.
         self.base_mut().set_visible(false);
@@ -73,6 +79,7 @@ impl CefTexture {
         self.app.audio_sample_rate = None;
         self.app.download_request_queue = None;
         self.app.download_update_queue = None;
+        self.app.audio_shutdown_flag = None;
 
         self.ime_active = false;
         self.ime_proxy = None;
@@ -217,6 +224,7 @@ impl CefTexture {
                 audio_packet_queue: queues.audio_packet_queue.clone(),
                 audio_params: queues.audio_params.clone(),
                 audio_sample_rate: queues.audio_sample_rate.clone(),
+                audio_shutdown_flag: queues.audio_shutdown_flag.clone(),
                 enable_audio_capture,
                 download_request_queue: queues.download_request_queue.clone(),
                 download_update_queue: queues.download_update_queue.clone(),
@@ -259,6 +267,7 @@ impl CefTexture {
         self.app.audio_sample_rate = Some(queues.audio_sample_rate);
         self.app.download_request_queue = Some(queues.download_request_queue);
         self.app.download_update_queue = Some(queues.download_update_queue);
+        self.app.audio_shutdown_flag = Some(queues.audio_shutdown_flag);
 
         Ok(browser)
     }
@@ -331,6 +340,7 @@ impl CefTexture {
                 audio_packet_queue: queues.audio_packet_queue.clone(),
                 audio_params: queues.audio_params.clone(),
                 audio_sample_rate: queues.audio_sample_rate.clone(),
+                audio_shutdown_flag: queues.audio_shutdown_flag.clone(),
                 enable_audio_capture,
                 download_request_queue: queues.download_request_queue.clone(),
                 download_update_queue: queues.download_update_queue.clone(),
@@ -379,6 +389,7 @@ impl CefTexture {
         self.app.audio_sample_rate = Some(queues.audio_sample_rate);
         self.app.download_request_queue = Some(queues.download_request_queue);
         self.app.download_update_queue = Some(queues.download_update_queue);
+        self.app.audio_shutdown_flag = Some(queues.audio_shutdown_flag);
 
         Ok(browser)
     }


### PR DESCRIPTION
Fixed the issue where closing the Godot game while audio capturing is active would produce the error:

```
ERROR: [CefAudioHandler] Audio stream error: Socket closed unexpectedly
```