### PR TITLE
fix: raise errors on invalid control size instead of crash

### DIFF
--- a/crates/gdcef/src/cef_texture/browser_lifecycle.rs
+++ b/crates/gdcef/src/cef_texture/browser_lifecycle.rs
@@ -105,6 +105,16 @@ impl CefTexture {
 
     pub(super) fn try_create_browser(&mut self) -> Result<(), CefError> {
         let logical_size = self.base().get_size();
+
+        // Validate size before attempting to create browser.
+        // A zero or negative size will crash CEF subprocess.
+        if logical_size.x <= 0.0 || logical_size.y <= 0.0 {
+            return Err(CefError::InvalidSize {
+                width: logical_size.x,
+                height: logical_size.y,
+            });
+        }
+
         let dpi = self.get_pixel_scale_factor();
         let pixel_width = (logical_size.x * dpi) as i32;
         let pixel_height = (logical_size.y * dpi) as i32;

--- a/crates/gdcef/src/error.rs
+++ b/crates/gdcef/src/error.rs
@@ -28,6 +28,8 @@ pub enum CefError {
     ResourceNotFound(String),
     /// GPU device access failed.
     GpuDeviceError(String),
+    /// Invalid texture size (zero or negative dimensions).
+    InvalidSize { width: f32, height: f32 },
 }
 
 impl fmt::Display for CefError {
@@ -54,6 +56,9 @@ impl fmt::Display for CefError {
             CefError::GpuDeviceError(msg) => {
                 write!(f, "GPU device error: {}", msg)
             }
+            CefError::InvalidSize { width, height } => {
+                write!(f, "Invalid texture size: {}x{}", width, height)
+            }
         }
     }
 }
@@ -67,7 +72,8 @@ impl std::error::Error for CefError {
             | CefError::BrowserCreationFailed(_)
             | CefError::TextureOperationFailed(_)
             | CefError::ResourceNotFound(_)
-            | CefError::GpuDeviceError(_) => None,
+            | CefError::GpuDeviceError(_)
+            | CefError::InvalidSize { .. } => None,
         }
     }
 }


### PR DESCRIPTION
## Description

raise errors on invalid control size instead of crash

## Related Issues

- Fixes #106

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🏗️ Build/CI changes

### Platforms Tested

<!-- Mark all platforms where you've tested this change -->

- [x] Windows (DirectX 12)
- [x] Windows (Vulkan)
- [x] macOS (Metal)
- [x] macOS (Software Rendering)
- [ ] Linux (Vulkan)
- [x] Linux (Software Rendering)
