### PR TITLE
fix: using older dxgi api for better compatibility

### DIFF
--- a/crates/gdcef/src/accelerated_osr/windows/d3d12.rs
+++ b/crates/gdcef/src/accelerated_osr/windows/d3d12.rs
@@ -14,7 +14,7 @@ use windows::Win32::Graphics::Direct3D12::{
     D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_TRANSITION_BARRIER, ID3D12CommandAllocator,
     ID3D12CommandQueue, ID3D12Device, ID3D12Fence, ID3D12GraphicsCommandList, ID3D12Resource,
 };
-use windows::Win32::Graphics::Dxgi::{CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory4};
+use windows::Win32::Graphics::Dxgi::{CreateDXGIFactory, IDXGIAdapter, IDXGIFactory};
 use windows::Win32::System::Threading::{
     CreateEventW, GetCurrentProcess, INFINITE, WaitForSingleObject,
 };
@@ -457,16 +457,17 @@ pub fn get_godot_gpu_device_ids() -> Option<(u32, u32)> {
     // Device is from Godot, we don't need to close it
     std::mem::forget(device);
 
-    let factory: IDXGIFactory4 = unsafe { CreateDXGIFactory1() }.ok()?;
+    // Use the original DXGI factory (available since Windows Vista) for maximum compatibility
+    let factory: IDXGIFactory = unsafe { CreateDXGIFactory() }.ok()?;
 
     let mut adapter_index = 0u32;
     loop {
-        let adapter: IDXGIAdapter1 = match unsafe { factory.EnumAdapters1(adapter_index) } {
+        let adapter: IDXGIAdapter = match unsafe { factory.EnumAdapters(adapter_index) } {
             Ok(a) => a,
             Err(_) => break, // No more adapters
         };
 
-        let desc = match unsafe { adapter.GetDesc1() } {
+        let desc = match unsafe { adapter.GetDesc() } {
             Ok(d) => d,
             Err(_) => {
                 adapter_index += 1;


### PR DESCRIPTION
## Description

Use older DXGI API (downgrade from DXGI 1.4 to DXGI 1.0) for better compatibility

## Related Issues

- Fixes #117 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🏗️ Build/CI changes

### Platforms Tested

<!-- Mark all platforms where you've tested this change -->

- [x] Windows (DirectX 12)
- [ ] Windows (Vulkan)
- [ ] macOS (Metal)
- [ ] macOS (Software Rendering)
- [ ] Linux (Vulkan)
- [ ] Linux (Software Rendering)

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have run `cargo fmt --all` to format my code
- [x] I have run `cargo clippy --workspace --all-features` and fixed all warnings
- [x] I have added/updated documentation for my changes (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] My changes don't introduce any new compiler warnings

## Additional Notes

<!-- Add any additional notes, concerns, or context for reviewers -->

---

<!-- 
Thank you for your contribution! 🎉

Before submitting, please ensure:
- Your branch is up to date with main
- CI checks pass
- The PR title follows conventional commits (feat:, fix:, docs:, etc.)
-->

