### PR TITLE
docs: add keep import instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ A high-performance Chromium Embedded Framework (CEF) integration for Godot Engin
 
 Download the latest pre-built binaries from the [Releases](https://github.com/dsh0416/godot-cef/releases) page, extract the addon to your Godot project's `addons/` folder, and you're ready to go!
 
+> [!NOTE]
+> During export/package builds, Godot may convert some imported assets into other formats. If your frontend is built with Vite and needs specific source files to remain as-is, you can use [`vite-plugin-godot-keep-import`](https://github.com/LemonNekoGH/vite-plugin-keep-import-for-godot) to keep imports for selected file types.
+
 ### Basic Usage
 
 ```gdscript

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,6 +6,10 @@ This section provides comprehensive documentation for the `CefTexture` node, whi
 
 Once the Godot CEF addon is installed, you can use the `CefTexture` node in your scenes:
 
+::: info Packaging note
+During export/package builds, Godot may convert some imported assets into other formats. If your frontend is built with Vite and needs specific source files to stay unchanged, consider using [`vite-plugin-godot-keep-import`](https://github.com/LemonNekoGH/vite-plugin-keep-import-for-godot) to keep imports for selected file types.
+:::
+
 ```gdscript
 extends Control
 

--- a/docs/zh_CN/api/index.md
+++ b/docs/zh_CN/api/index.md
@@ -6,6 +6,10 @@
 
 安装 Godot CEF 插件后，您可以直接在场景中使用 `CefTexture`：
 
+::: info 打包说明
+在导出/打包阶段，Godot 可能会把部分已导入资源转换为其他格式。如果您的前端使用 Vite，且需要让某些源文件保持原样，可考虑使用 [`vite-plugin-godot-keep-import`](https://github.com/LemonNekoGH/vite-plugin-keep-import-for-godot) 来为指定文件类型保留 import。
+:::
+
 ```gdscript
 extends Control
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior or build outputs.
> 
> **Overview**
> Adds a **packaging/export caveat** to the `README` and both English/Chinese API getting-started docs, warning that Godot may transform imported assets during export and recommending `vite-plugin-godot-keep-import` for Vite projects that need certain source files to remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f77c8fc9027a0e77744e35eacb9352c46b8bef0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->