### PR TITLE
fix: optimus export issue

### DIFF
--- a/crates/gdcef_helper/build.rs
+++ b/crates/gdcef_helper/build.rs
@@ -8,8 +8,9 @@ fn main() {
     // Without these exports, the NVIDIA Optimus driver won't route gdcef_helper.exe
     // to the discrete GPU, causing cross-GPU shared texture handle failures on
     // laptops with hybrid graphics.
-    #[cfg(target_os = "windows")]
-    {
+    // Build scripts are compiled for the host, so use Cargo's target cfg env var
+    // instead of #[cfg(target_os = "...")] to detect the compilation target.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-arg=/EXPORT:NvOptimusEnablement,DATA");
         println!("cargo:rustc-link-arg=/EXPORT:AmdPowerXpressRequestHighPerformance,DATA");
     }


### PR DESCRIPTION
## Description

Fix the missing optimus symbols.

## Related Issues

Possibly related to #117 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I tested my changes locally
- [x] I updated docs/tests if needed
- [x] CI passes (or I explained why it does not)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Windows-only build/linker change; primary risk is unintended linker/packaging issues for the `gdcef_helper` binary on MSVC builds.
> 
> **Overview**
> Ensures `gdcef_helper` on Windows exports `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance` in the PE export table by adding a `build.rs` that passes MSVC linker `/EXPORT:` args.
> 
> This is intended to force NVIDIA/AMD hybrid-graphics laptops to run `gdcef_helper.exe` on the discrete GPU and avoid cross-GPU shared texture handle failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f9af1d6e19dbf3a4a7963f0341591b12b970ae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->