### PR TITLE
feat: allow to load preload script before document load

### DIFF
--- a/crates/cef_app/src/ipc_contract.rs
+++ b/crates/cef_app/src/ipc_contract.rs
@@ -17,3 +17,5 @@ pub const ROUTE_IPC_DATA_RENDERER_TO_GODOT: &str = "ipcDataRendererToGodot";
 
 pub const ROUTE_TRIGGER_IME: &str = "triggerIme";
 pub const ROUTE_IME_CARET_POSITION: &str = "imeCaretPosition";
+
+pub const EXTRA_INFO_PRELOAD_SCRIPT: &str = "godotCefPreloadScript";

--- a/crates/cef_app/src/render_process.rs
+++ b/crates/cef_app/src/render_process.rs
@@ -1,17 +1,19 @@
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
 
 use cef::{
-    Browser, CefStringUtf16, Domnode, Frame, ImplBinaryValue, ImplDomnode, ImplFrame,
-    ImplListValue, ImplProcessMessage, ImplRenderProcessHandler, ImplV8Context, ImplV8Value,
-    ProcessId, ProcessMessage, RenderProcessHandler, V8Context, V8Handler, V8Value,
+    Browser, CefStringUtf16, DictionaryValue, Domnode, Frame, ImplBinaryValue, ImplBrowser,
+    ImplDictionaryValue, ImplDomnode, ImplFrame, ImplListValue, ImplProcessMessage,
+    ImplRenderProcessHandler, ImplV8Context, ImplV8Exception, ImplV8Value, ProcessId,
+    ProcessMessage, RenderProcessHandler, V8Context, V8Exception, V8Handler, V8Value,
     WrapRenderProcessHandler, process_message_create, rc::Rc,
     v8_value_create_array_buffer_with_copy, v8_value_create_function, v8_value_create_string,
     wrap_render_process_handler,
 };
 
 use crate::ipc_contract::{
-    ROUTE_IPC_BINARY_GODOT_TO_RENDERER, ROUTE_IPC_DATA_GODOT_TO_RENDERER,
-    ROUTE_IPC_GODOT_TO_RENDERER, ROUTE_TRIGGER_IME,
+    EXTRA_INFO_PRELOAD_SCRIPT, ROUTE_IPC_BINARY_GODOT_TO_RENDERER,
+    ROUTE_IPC_DATA_GODOT_TO_RENDERER, ROUTE_IPC_GODOT_TO_RENDERER, ROUTE_TRIGGER_IME,
 };
 use crate::v8_handlers::{
     IpcListenerSet, OsrImeCaretHandler, OsrImeCaretHandlerBuilder, OsrIpcBinaryHandler,
@@ -31,6 +33,48 @@ fn send_browser_bool_message(frame: Option<&mut Frame>, route: &str, value: bool
         argument_list.set_bool(0, value as _);
     }
     frame.send_process_message(ProcessId::BROWSER, Some(&mut process_message));
+}
+
+// `extra_info` is only available in `on_browser_created`, while preload runs
+// later in `on_context_created`. These callbacks can arrive through different
+// Rust wrapper instances, so handler fields cannot carry preload state between
+// them. Browser identifiers remain stable across those callbacks.
+static PRELOAD_SCRIPTS: LazyLock<Mutex<HashMap<i32, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn log_preload_exception(exception: Option<V8Exception>) {
+    let Some(exception) = exception else {
+        eprintln!("[GodotCef] Preload script failed without exception details");
+        return;
+    };
+
+    let message = CefStringUtf16::from(&exception.message()).to_string();
+    let source_line = CefStringUtf16::from(&exception.source_line()).to_string();
+    eprintln!(
+        "[GodotCef] Preload script failed at line {}: {}\n{}",
+        exception.line_number(),
+        message,
+        source_line
+    );
+}
+
+fn eval_preload_script(context: &mut V8Context, script: &str) {
+    let code: CefStringUtf16 = script.into();
+    // Used in dev tools for easier debugging of preload scripts. Not a real URL.
+    let script_url: CefStringUtf16 = "godot-cef://user-preload.js".into();
+    let mut retval: Option<V8Value> = None;
+    let mut exception: Option<V8Exception> = None;
+
+    if context.eval(
+        Some(&code),
+        Some(&script_url),
+        1,
+        Some(&mut retval),
+        Some(&mut exception),
+    ) == 0
+    {
+        log_preload_exception(exception);
+    }
 }
 
 #[derive(Clone)]
@@ -56,36 +100,100 @@ wrap_render_process_handler! {
     }
 
     impl RenderProcessHandler {
-        fn on_context_created(&self, _browser: Option<&mut Browser>, frame: Option<&mut Frame>, context: Option<&mut V8Context>) {
-            if let Some(context) = context {
-                let global = context.global();
-                if let Some(global) = global
-                    && let Some(frame) = frame {
-                        let frame_arc = Arc::new(Mutex::new(frame.clone()));
+        fn on_browser_created(
+            &self,
+            browser: Option<&mut Browser>,
+            extra_info: Option<&mut DictionaryValue>,
+        ) {
+            let Some(browser) = browser else {
+                return;
+            };
+            let browser_id = browser.identifier();
 
-                        register_v8_function(&global, "sendIpcMessage",
-                            &mut OsrIpcHandlerBuilder::build(OsrIpcHandler::new(Some(frame_arc.clone()))));
-                        register_v8_function(&global, "sendIpcBinaryMessage",
-                            &mut OsrIpcBinaryHandlerBuilder::build(OsrIpcBinaryHandler::new(Some(frame_arc.clone()))));
-                        register_v8_function(&global, "sendIpcData",
-                            &mut OsrIpcDataHandlerBuilder::build(OsrIpcDataHandler::new(Some(frame_arc.clone()))));
+            let key: CefStringUtf16 = EXTRA_INFO_PRELOAD_SCRIPT.into();
+            let Ok(mut preload_scripts) = PRELOAD_SCRIPTS.lock() else {
+                eprintln!("[GodotCef] preload cache lock failed in on_browser_created");
+                return;
+            };
+            preload_scripts.remove(&browser_id);
 
-                        for (name, listeners) in [
-                            ("ipcMessage", &self.handler.string_listeners),
-                            ("ipcBinaryMessage", &self.handler.binary_listeners),
-                            ("ipcDataMessage", &self.handler.data_listeners),
-                        ] {
-                            if let Some(mut obj) = listeners.build_api_object() {
-                                register_v8_value(&global, name, &mut obj);
-                            }
-                        }
+            let Some(extra_info) = extra_info else {
+                return;
+            };
+            if extra_info.has_key(Some(&key)) == 0 {
+                return;
+            }
 
-                        register_v8_function(&global, "__sendImeCaretPosition",
-                            &mut OsrImeCaretHandlerBuilder::build(OsrImeCaretHandler::new(Some(frame_arc))));
+            let script = CefStringUtf16::from(&extra_info.string(Some(&key))).to_string();
+            if script.is_empty() {
+                return;
+            }
 
-                        let helper_script: cef::CefStringUtf16 = include_str!("ime_helper.js").into();
-                        frame.execute_java_script(Some(&helper_script), None, 0);
-                    }
+            preload_scripts.insert(browser_id, script);
+        }
+
+        fn on_context_created(&self, browser: Option<&mut Browser>, frame: Option<&mut Frame>, context: Option<&mut V8Context>) {
+            let Some(context) = context else {
+                return;
+            };
+            let Some(global) = context.global() else {
+                return;
+            };
+            let Some(frame) = frame else {
+                return;
+            };
+
+            let frame_arc = Arc::new(Mutex::new(frame.clone()));
+
+            register_v8_function(&global, "sendIpcMessage",
+                &mut OsrIpcHandlerBuilder::build(OsrIpcHandler::new(Some(frame_arc.clone()))));
+            register_v8_function(&global, "sendIpcBinaryMessage",
+                &mut OsrIpcBinaryHandlerBuilder::build(OsrIpcBinaryHandler::new(Some(frame_arc.clone()))));
+            register_v8_function(&global, "sendIpcData",
+                &mut OsrIpcDataHandlerBuilder::build(OsrIpcDataHandler::new(Some(frame_arc.clone()))));
+
+            for (name, listeners) in [
+                ("ipcMessage", &self.handler.string_listeners),
+                ("ipcBinaryMessage", &self.handler.binary_listeners),
+                ("ipcDataMessage", &self.handler.data_listeners),
+            ] {
+                if let Some(mut obj) = listeners.build_api_object() {
+                    register_v8_value(&global, name, &mut obj);
+                }
+            }
+
+            register_v8_function(&global, "__sendImeCaretPosition",
+                &mut OsrImeCaretHandlerBuilder::build(OsrImeCaretHandler::new(Some(frame_arc))));
+
+            let helper_script: cef::CefStringUtf16 = include_str!("ime_helper.js").into();
+            frame.execute_java_script(Some(&helper_script), None, 0);
+
+            if frame.is_main() == 0 {
+                return;
+            }
+            let Some(browser) = browser else {
+                return;
+            };
+            let browser_id = browser.identifier();
+            let preload_script = PRELOAD_SCRIPTS
+                .lock()
+                .ok()
+                .and_then(|scripts| scripts.get(&browser_id).cloned());
+            let Some(preload_script) = preload_script else {
+                return;
+            };
+
+            eval_preload_script(context, &preload_script);
+        }
+
+        fn on_browser_destroyed(&self, browser: Option<&mut Browser>) {
+            let Some(browser) = browser else {
+                return;
+            };
+            if let Ok(mut preload_scripts) = PRELOAD_SCRIPTS.lock() {
+                preload_scripts.remove(&browser.identifier());
+            } else {
+                eprintln!("[GodotCef] preload cache lock failed in on_browser_destroyed");
             }
         }
 

--- a/crates/gdcef/src/browser.rs
+++ b/crates/gdcef/src/browser.rs
@@ -559,7 +559,6 @@ pub enum LifecycleState {
     Running,
     Closing,
     Closed,
-    Failed,
 }
 
 #[derive(Default)]
@@ -616,7 +615,7 @@ impl App {
     pub fn can_create_browser(&self) -> bool {
         !matches!(
             self.lifecycle_state,
-            LifecycleState::Creating | LifecycleState::Running | LifecycleState::Failed
+            LifecycleState::Creating | LifecycleState::Running
         )
     }
 
@@ -643,10 +642,6 @@ impl App {
         } else {
             LifecycleState::Closed
         };
-    }
-
-    pub fn mark_browser_failed(&mut self) {
-        self.lifecycle_state = LifecycleState::Failed;
     }
 
     /// Releases CEF only when this instance currently owns a retain reference.
@@ -694,11 +689,6 @@ mod tests {
         assert!(app.begin_browser_create());
         assert_eq!(app.lifecycle_state(), LifecycleState::Creating);
         assert!(!app.can_create_browser());
-
-        app.mark_browser_failed();
-        assert_eq!(app.lifecycle_state(), LifecycleState::Failed);
-        assert!(!app.can_create_browser());
-        assert!(!app.begin_browser_create());
 
         app.mark_browser_closed();
         assert!(app.can_create_browser());

--- a/crates/gdcef/src/browser.rs
+++ b/crates/gdcef/src/browser.rs
@@ -559,6 +559,7 @@ pub enum LifecycleState {
     Running,
     Closing,
     Closed,
+    Failed,
 }
 
 #[derive(Default)]
@@ -611,12 +612,17 @@ impl App {
         self.lifecycle_state = LifecycleState::Retained;
     }
 
+    /// Returns whether this instance can start browser creation.
+    pub fn can_create_browser(&self) -> bool {
+        !matches!(
+            self.lifecycle_state,
+            LifecycleState::Creating | LifecycleState::Running | LifecycleState::Failed
+        )
+    }
+
     /// Marks transition into browser creation.
     pub fn begin_browser_create(&mut self) -> bool {
-        if matches!(
-            self.lifecycle_state,
-            LifecycleState::Creating | LifecycleState::Running
-        ) {
+        if !self.can_create_browser() {
             return false;
         }
         self.lifecycle_state = LifecycleState::Creating;
@@ -637,6 +643,10 @@ impl App {
         } else {
             LifecycleState::Closed
         };
+    }
+
+    pub fn mark_browser_failed(&mut self) {
+        self.lifecycle_state = LifecycleState::Failed;
     }
 
     /// Releases CEF only when this instance currently owns a retain reference.
@@ -679,12 +689,25 @@ mod tests {
 
         app.mark_cef_retained();
         assert_eq!(app.lifecycle_state(), LifecycleState::Retained);
+        assert!(app.can_create_browser());
 
+        assert!(app.begin_browser_create());
+        assert_eq!(app.lifecycle_state(), LifecycleState::Creating);
+        assert!(!app.can_create_browser());
+
+        app.mark_browser_failed();
+        assert_eq!(app.lifecycle_state(), LifecycleState::Failed);
+        assert!(!app.can_create_browser());
+        assert!(!app.begin_browser_create());
+
+        app.mark_browser_closed();
+        assert!(app.can_create_browser());
         assert!(app.begin_browser_create());
         assert_eq!(app.lifecycle_state(), LifecycleState::Creating);
 
         app.mark_browser_running();
         assert_eq!(app.lifecycle_state(), LifecycleState::Running);
+        assert!(!app.can_create_browser());
 
         app.mark_browser_closing();
         assert_eq!(app.lifecycle_state(), LifecycleState::Closing);

--- a/crates/gdcef/src/cef_texture/backend.rs
+++ b/crates/gdcef/src/cef_texture/backend.rs
@@ -1,7 +1,13 @@
 use adblock::lists::{FilterSet, ParseOptions};
-use cef::{BrowserSettings, ImplBrowser, ImplBrowserHost, RequestContextSettings, WindowInfo};
+use cef::{
+    BrowserSettings, CefStringUtf16, ImplBrowser, ImplBrowserHost, ImplDictionaryValue,
+    RequestContextSettings, WindowInfo,
+};
 use cef_app::PhysicalSize;
+use cef_app::ipc_contract::EXTRA_INFO_PRELOAD_SCRIPT;
+use godot::classes::FileAccess;
 use godot::classes::Image;
+use godot::classes::file_access::ModeFlags;
 use godot::classes::image::Format as ImageFormat;
 use godot::classes::{AudioServer, DisplayServer, Engine, ImageTexture, Texture2Drd};
 use godot::prelude::*;
@@ -29,6 +35,8 @@ pub(crate) struct BackendCreateParams {
     pub enable_accelerated_osr: bool,
     pub background_color: Color,
     pub popup_policy: i32,
+    pub preload_script: String,
+    pub preload_script_path: String,
     pub software_target_texture: Option<Gd<ImageTexture>>,
     pub log_prefix: &'static str,
 }
@@ -38,6 +46,8 @@ struct BrowserCreateParams {
     dpi: f32,
     pixel_width: i32,
     pixel_height: i32,
+    url: String,
+    preload_script: Option<String>,
     popup_policy: PopupPolicyFlag,
     permission_policy: crate::browser::PermissionPolicyFlag,
     permission_request_counter: crate::browser::PermissionRequestIdCounter,
@@ -100,6 +110,66 @@ pub(crate) fn should_use_accelerated_osr(enable_accelerated_osr: bool, log_prefi
         );
     }
     supported
+}
+
+fn resolve_preload_script(script: &str, path: &str) -> Result<Option<String>, CefError> {
+    if !script.is_empty() && !path.is_empty() {
+        return Err(CefError::BrowserCreationFailed(
+            "`preload_script` and `preload_script_path` cannot both be set".into(),
+        ));
+    }
+
+    if !script.is_empty() {
+        return Ok(Some(script.to_string()));
+    }
+
+    if path.is_empty() {
+        return Ok(None);
+    }
+
+    let gstring_path = GString::from(path);
+    let Some(file) = FileAccess::open(&gstring_path, ModeFlags::READ) else {
+        return Err(CefError::BrowserCreationFailed(format!(
+            "failed to open preload_script_path '{}'",
+            path
+        )));
+    };
+
+    let file_size = file.get_length();
+    if file_size > i64::MAX as u64 {
+        return Err(CefError::BrowserCreationFailed(format!(
+            "preload_script_path '{}' is too large",
+            path
+        )));
+    }
+
+    let bytes = file.get_buffer(file_size as i64);
+    String::from_utf8(bytes.to_vec()).map(Some).map_err(|err| {
+        CefError::BrowserCreationFailed(format!(
+            "preload_script_path '{}' is not valid UTF-8: {}",
+            path, err
+        ))
+    })
+}
+
+fn build_browser_extra_info(
+    preload_script: Option<&str>,
+) -> Result<cef::DictionaryValue, CefError> {
+    let Some(extra_info) = cef::dictionary_value_create() else {
+        return Err(CefError::BrowserCreationFailed(
+            "failed to create preload extra_info dictionary".into(),
+        ));
+    };
+
+    let key: CefStringUtf16 = EXTRA_INFO_PRELOAD_SCRIPT.into();
+    let value: CefStringUtf16 = preload_script.unwrap_or("").into();
+    if extra_info.set_string(Some(&key), Some(&value)) == 0 {
+        return Err(CefError::BrowserCreationFailed(
+            "failed to write preload script to extra_info".into(),
+        ));
+    }
+
+    Ok(extra_info)
 }
 
 pub(crate) fn get_max_fps() -> i32 {
@@ -386,10 +456,14 @@ pub(crate) fn try_create_browser(
         godot_protocol::register_user_scheme_handler_on_context(ctx);
     }
 
+    let preload_script =
+        resolve_preload_script(&params.preload_script, &params.preload_script_path)?;
     let create_params = BrowserCreateParams {
         dpi: params.dpi,
         pixel_width,
         pixel_height,
+        url: params.url.clone(),
+        preload_script,
         popup_policy,
         permission_policy,
         permission_request_counter,
@@ -404,7 +478,6 @@ pub(crate) fn try_create_browser(
             &browser_settings,
             context.as_mut(),
             create_params,
-            &params.url,
             params.log_prefix,
         )?;
     } else {
@@ -414,7 +487,6 @@ pub(crate) fn try_create_browser(
             context.as_mut(),
             create_params,
             params.software_target_texture.clone(),
-            &params.url,
             params.log_prefix,
         )?;
     }
@@ -483,13 +555,14 @@ fn create_software_browser(
     context: Option<&mut cef::RequestContext>,
     params: BrowserCreateParams,
     software_target_texture: Option<Gd<ImageTexture>>,
-    url: &str,
     log_prefix: &str,
 ) -> Result<(), CefError> {
     let BrowserCreateParams {
         dpi,
         pixel_width,
         pixel_height,
+        url,
+        preload_script,
         popup_policy,
         permission_policy,
         permission_request_counter,
@@ -556,13 +629,15 @@ fn create_software_browser(
         queues.clone(),
         popup_policy.clone(),
     );
+    let mut extra_info = build_browser_extra_info(preload_script.as_deref())?;
+    let cef_url: CefStringUtf16 = url.as_str().into();
 
     let browser = cef::browser_host_create_browser_sync(
         Some(&window_info),
         Some(&mut client),
-        Some(&url.into()),
+        Some(&cef_url),
         Some(browser_settings),
-        None,
+        Some(&mut extra_info),
         context,
     )
     .ok_or_else(|| {
@@ -597,7 +672,6 @@ fn create_accelerated_browser(
     browser_settings: &BrowserSettings,
     context: Option<&mut cef::RequestContext>,
     params: BrowserCreateParams,
-    url: &str,
     log_prefix: &str,
 ) -> Result<(), CefError> {
     godot::global::godot_print!(
@@ -617,7 +691,6 @@ fn create_accelerated_browser(
                 context,
                 params,
                 None,
-                url,
                 log_prefix,
             );
         }
@@ -626,6 +699,8 @@ fn create_accelerated_browser(
         dpi,
         pixel_width,
         pixel_height,
+        url,
+        preload_script,
         popup_policy,
         permission_policy,
         permission_request_counter,
@@ -670,13 +745,15 @@ fn create_accelerated_browser(
         queues.clone(),
         popup_policy.clone(),
     );
+    let mut extra_info = build_browser_extra_info(preload_script.as_deref())?;
+    let cef_url: CefStringUtf16 = url.as_str().into();
 
     let browser = match cef::browser_host_create_browser_sync(
         Some(window_info),
         Some(&mut client),
-        Some(&url.into()),
+        Some(&cef_url),
         Some(browser_settings),
-        None,
+        Some(&mut extra_info),
         context,
     ) {
         Some(browser) => browser,
@@ -715,18 +792,9 @@ fn create_accelerated_browser(
     browser_settings: &BrowserSettings,
     context: Option<&mut cef::RequestContext>,
     params: BrowserCreateParams,
-    url: &str,
     log_prefix: &str,
 ) -> Result<(), CefError> {
-    create_software_browser(
-        app,
-        browser_settings,
-        context,
-        params,
-        None,
-        url,
-        log_prefix,
-    )
+    create_software_browser(app, browser_settings, context, params, None, log_prefix)
 }
 
 #[cfg(test)]

--- a/crates/gdcef/src/cef_texture/browser_lifecycle.rs
+++ b/crates/gdcef/src/cef_texture/browser_lifecycle.rs
@@ -76,7 +76,7 @@ impl CefTexture {
             log_prefix: "CefTexture",
         };
         if let Err(err) = self.with_app_mut(|app| backend::try_create_browser(app, &params)) {
-            self.with_app_mut(|app| app.mark_browser_failed());
+            self.with_app_mut(|app| app.mark_browser_closed());
             return Err(err);
         }
         self.with_app_mut(|app| app.mark_browser_running());

--- a/crates/gdcef/src/cef_texture/browser_lifecycle.rs
+++ b/crates/gdcef/src/cef_texture/browser_lifecycle.rs
@@ -70,11 +70,13 @@ impl CefTexture {
             enable_accelerated_osr: self.enable_accelerated_osr,
             background_color: self.background_color,
             popup_policy: self.popup_policy,
+            preload_script: self.preload_script.to_string(),
+            preload_script_path: self.preload_script_path.to_string(),
             software_target_texture: None,
             log_prefix: "CefTexture",
         };
         if let Err(err) = self.with_app_mut(|app| backend::try_create_browser(app, &params)) {
-            self.with_app_mut(|app| app.mark_browser_closed());
+            self.with_app_mut(|app| app.mark_browser_failed());
             return Err(err);
         }
         self.with_app_mut(|app| app.mark_browser_running());

--- a/crates/gdcef/src/cef_texture/mod.rs
+++ b/crates/gdcef/src/cef_texture/mod.rs
@@ -51,6 +51,16 @@ pub struct CefTexture {
     /// SignalOnly: emit `popup_requested` signal and let GDScript decide.
     popup_policy: i32,
 
+    #[export]
+    #[var(get = get_preload_script, set = set_preload_script)]
+    /// JavaScript source to inject into the main frame when its V8 context is created.
+    preload_script: GString,
+
+    #[export]
+    #[var(get = get_preload_script_path, set = set_preload_script_path)]
+    /// Godot file path containing JavaScript to inject as a preload script.
+    preload_script_path: GString,
+
     #[var]
     /// Stores the IME cursor position in local coordinates (relative to this `CefTexture` node),
     /// automatically updated from the browser's caret position.
@@ -95,6 +105,8 @@ impl ITextureRect for CefTexture {
             enable_accelerated_osr: true,
             background_color: Color::from_rgba(0.0, 0.0, 0.0, 0.0),
             popup_policy: crate::browser::popup_policy::BLOCK,
+            preload_script: GString::new(),
+            preload_script_path: GString::new(),
             ime_position: Vector2i::new(0, 0),
             texture2d_helper,
             last_size: Vector2::ZERO,
@@ -276,7 +288,7 @@ impl CefTexture {
     fn on_process(&mut self) {
         // Lazy browser creation: if browser doesn't exist yet (e.g., size was 0 in on_ready
         // because we're inside a Container), try to create it now that layout may be complete.
-        if self.with_app(|app| app.state.is_none()) {
+        if self.with_app(|app| app.state.is_none() && app.can_create_browser()) {
             let size = self.base().get_size();
             if size.x > 0.0 && size.y > 0.0 && !self.browser_create_deferred_pending {
                 self.browser_create_deferred_pending = true;
@@ -400,6 +412,30 @@ impl CefTexture {
     fn set_background_color(&mut self, color: Color) {
         self.background_color = color;
         self.texture2d_helper.bind_mut().set_background_color(color);
+    }
+
+    #[func]
+    fn get_preload_script(&self) -> GString {
+        self.preload_script.clone()
+    }
+
+    #[func]
+    fn set_preload_script(&mut self, script: GString) {
+        self.preload_script = script.clone();
+        self.texture2d_helper.bind_mut().set_preload_script(script);
+    }
+
+    #[func]
+    fn get_preload_script_path(&self) -> GString {
+        self.preload_script_path.clone()
+    }
+
+    #[func]
+    fn set_preload_script_path(&mut self, path: GString) {
+        self.preload_script_path = path.clone();
+        self.texture2d_helper
+            .bind_mut()
+            .set_preload_script_path(path);
     }
 
     #[func]

--- a/crates/gdcef/src/cef_texture2d/api.rs
+++ b/crates/gdcef/src/cef_texture2d/api.rs
@@ -58,6 +58,26 @@ impl CefTexture2D {
     }
 
     #[func]
+    pub(crate) fn get_preload_script(&self) -> GString {
+        self.preload_script.clone()
+    }
+
+    #[func]
+    pub(crate) fn set_preload_script(&mut self, script: GString) {
+        self.preload_script = script;
+    }
+
+    #[func]
+    pub(crate) fn get_preload_script_path(&self) -> GString {
+        self.preload_script_path.clone()
+    }
+
+    #[func]
+    pub(crate) fn set_preload_script_path(&mut self, path: GString) {
+        self.preload_script_path = path;
+    }
+
+    #[func]
     pub(crate) fn get_texture_size_property(&self) -> Vector2i {
         self.texture_size
     }

--- a/crates/gdcef/src/cef_texture2d/lifecycle.rs
+++ b/crates/gdcef/src/cef_texture2d/lifecycle.rs
@@ -36,6 +36,8 @@ impl CefTexture2D {
             enable_accelerated_osr: self.enable_accelerated_osr,
             background_color: self.background_color,
             popup_policy: self.popup_policy,
+            preload_script: self.preload_script.clone(),
+            preload_script_path: self.preload_script_path.clone(),
             software_target_texture: Some(self.fallback_texture.clone()),
             log_prefix: "CefTexture2D",
         });

--- a/crates/gdcef/src/cef_texture2d/mod.rs
+++ b/crates/gdcef/src/cef_texture2d/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct RuntimeCreateConfig {
     enable_accelerated_osr: bool,
     background_color: Color,
     popup_policy: i32,
+    preload_script: GString,
+    preload_script_path: GString,
     software_target_texture: Option<Gd<ImageTexture>>,
     log_prefix: &'static str,
 }
@@ -76,6 +78,14 @@ pub struct CefTexture2D {
     #[export(enum = (Block = 0, Redirect = 1, SignalOnly = 2))]
     #[var(get = get_popup_policy, set = set_popup_policy)]
     popup_policy: i32,
+
+    #[export]
+    #[var(get = get_preload_script, set = set_preload_script)]
+    preload_script: GString,
+
+    #[export]
+    #[var(get = get_preload_script_path, set = set_preload_script_path)]
+    preload_script_path: GString,
 
     #[export]
     #[var(get = get_texture_size_property, set = set_texture_size_property)]
@@ -117,6 +127,8 @@ impl ITexture2D for CefTexture2D {
             enable_accelerated_osr: true,
             background_color: Color::from_rgba(0.0, 0.0, 0.0, 0.0),
             popup_policy: crate::browser::popup_policy::BLOCK,
+            preload_script: GString::new(),
+            preload_script_path: GString::new(),
             texture_size,
             last_find_query: GString::new(),
             last_find_match_case: false,

--- a/crates/gdcef/src/cef_texture2d/runtime.rs
+++ b/crates/gdcef/src/cef_texture2d/runtime.rs
@@ -63,10 +63,12 @@ impl CefTextureRuntime {
             enable_accelerated_osr,
             background_color,
             popup_policy,
+            preload_script,
+            preload_script_path,
             software_target_texture,
             log_prefix,
         } = config;
-        if !self.runtime_enabled || self.app.state.is_some() {
+        if !self.runtime_enabled || self.app.state.is_some() || !self.app.can_create_browser() {
             return;
         }
         if let Err(e) = cef_init::cef_retain() {
@@ -82,12 +84,15 @@ impl CefTextureRuntime {
             enable_accelerated_osr,
             background_color,
             popup_policy,
+            preload_script: preload_script.to_string(),
+            preload_script_path: preload_script_path.to_string(),
             software_target_texture,
             log_prefix,
         };
         if let Err(e) = backend::try_create_browser(&mut self.app, &params) {
             godot::global::godot_error!("[{}] {}", log_prefix, e);
             self.app.release_cef_if_retained();
+            self.app.mark_browser_failed();
             return;
         }
         self.last_size = logical_size;

--- a/crates/gdcef/src/cef_texture2d/runtime.rs
+++ b/crates/gdcef/src/cef_texture2d/runtime.rs
@@ -92,7 +92,6 @@ impl CefTextureRuntime {
         if let Err(e) = backend::try_create_browser(&mut self.app, &params) {
             godot::global::godot_error!("[{}] {}", log_prefix, e);
             self.app.release_cef_if_retained();
-            self.app.mark_browser_failed();
             return;
         }
         self.last_size = logical_size;

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -164,6 +164,10 @@ cef_texture.stop_finding()
 
 Executes JavaScript code in the browser's main frame.
 
+For JavaScript that must be available before the page document loads, use the
+`preload_script` or `preload_script_path` properties instead of calling `eval`
+after navigation.
+
 ```gdscript
 # Execute JavaScript
 cef_texture.eval("document.body.style.backgroundColor = 'red'")

--- a/docs/api/properties.md
+++ b/docs/api/properties.md
@@ -17,6 +17,8 @@ foundation for runtime/settings behavior. It can be assigned directly to
 | `enable_accelerated_osr` | `bool` | `true` | Enable GPU-accelerated rendering |
 | `background_color` | `Color` | `Color(0, 0, 0, 0)` | Background color for the browser. Set alpha to 0 for transparent background, or use a solid color to disable transparency. |
 | `popup_policy` | `int` | `0` | Controls how popup windows are handled. `0` = BLOCK (suppress silently), `1` = REDIRECT (navigate current browser to popup URL), `2` = SIGNAL_ONLY (emit `popup_requested` signal). Can be changed at runtime. |
+| `preload_script` | `String` | `""` | JavaScript source executed once for the browser's main frame after the JS bridge is registered and before the document loads. Mutually exclusive with `preload_script_path`. |
+| `preload_script_path` | `String` | `""` | Godot file path for JavaScript source to preload. Supports Godot paths such as `res://` and `user://`. Mutually exclusive with `preload_script`. |
 
 ## CefTexture2D Properties
 
@@ -26,6 +28,8 @@ foundation for runtime/settings behavior. It can be assigned directly to
 | `enable_accelerated_osr` | `bool` | `true` | Enables accelerated OSR when supported, otherwise falls back to software rendering. |
 | `background_color` | `Color` | `Color(0, 0, 0, 0)` | Browser background color (supports transparency). |
 | `popup_policy` | `int` | `0` | Popup behavior policy: BLOCK/REDIRECT/SIGNAL_ONLY. |
+| `preload_script` | `String` | `""` | JavaScript source executed once for the browser's main frame after the JS bridge is registered and before the document loads. Mutually exclusive with `preload_script_path`. |
+| `preload_script_path` | `String` | `""` | Godot file path for JavaScript source to preload. Supports Godot paths such as `res://` and `user://`. Mutually exclusive with `preload_script`. |
 | `texture_size` | `Vector2i` | `Vector2i(1024, 1024)` | Logical browser texture size in pixels. |
 
 `CefTexture2D` v1 is intentionally render-only: it does not include built-in
@@ -59,6 +63,51 @@ var mat := StandardMaterial3D.new()
 mat.albedo_texture = browser_tex
 $MeshInstance3D.set_surface_override_material(0, mat)
 ```
+
+## Preload Scripts
+
+Use `preload_script` or `preload_script_path` to install trusted app-provided
+JavaScript before the page document loads. Preload runs after Godot CEF
+registers its built-in JavaScript bridge, so APIs such as
+`window.sendIpcMessage(...)` are available inside the preload script.
+
+Set preload properties before the browser instance is created. For `CefTexture`,
+this means before the node enters the scene tree or before its browser is
+otherwise initialized. For `CefTexture2D`, set them before the resource-backed
+browser is initialized by the scene using it. For a `CefTexture` already present
+in a scene, set these properties in the Inspector.
+
+```gdscript
+func _ready() -> void:
+    var browser := CefTexture.new()
+    browser.preload_script = """
+        window.appConfig = { locale: "en-US" };
+        window.sendIpcMessage("preload-ready");
+    """
+    browser.url = "res://ui/index.html"
+    add_child(browser)
+```
+
+For larger scripts, store the JavaScript in a file and set
+`preload_script_path`:
+
+```gdscript
+browser.preload_script_path = "res://browser/preload.js"
+browser.url = "https://example.com"
+```
+
+`preload_script` and `preload_script_path` are mutually exclusive. If both are
+non-empty, browser creation fails with an error. If `preload_script_path` cannot
+be opened or is not valid UTF-8, browser creation also fails.
+
+Preload only runs in the main frame. It does not run in iframes.
+
+::: warning Trusted code only
+Preload executes in the page's main JavaScript world. It is intended for trusted
+application setup, such as installing app globals or wiring IPC. It is not a
+security isolation boundary, and it should not contain secrets that the loaded
+page must not read.
+:::
 
 ## Project Settings
 

--- a/docs/zh_CN/api/methods.md
+++ b/docs/zh_CN/api/methods.md
@@ -123,6 +123,9 @@ if cef_texture.is_loading():
 
 在浏览器主 Frame（main frame）中执行 JavaScript 代码。
 
+如果 JavaScript 必须在页面 document 加载前可用，请使用
+`preload_script` 或 `preload_script_path` 属性，而不是导航后再调用 `eval`。
+
 ```gdscript
 # Execute JavaScript
 cef_texture.eval("document.body.style.backgroundColor = 'red'")

--- a/docs/zh_CN/api/properties.md
+++ b/docs/zh_CN/api/properties.md
@@ -17,6 +17,8 @@
 | `enable_accelerated_osr` | `bool` | `true` | 启用 GPU 加速渲染 |
 | `background_color` | `Color` | `Color(0, 0, 0, 0)` | 浏览器背景色。将 alpha 设为 0 表示透明背景，或使用实色以禁用透明效果。 |
 | `popup_policy` | `int` | `0` | 控制弹出窗口的处理方式。`0` = BLOCK（静默阻止），`1` = REDIRECT（在当前浏览器中导航到弹出 URL），`2` = SIGNAL_ONLY（触发 `popup_requested` 信号）。可在运行时更改。 |
+| `preload_script` | `String` | `""` | 在 JS Bridge 注册之后、document 加载之前，为浏览器主 Frame 执行的 JavaScript 源码。与 `preload_script_path` 互斥。 |
+| `preload_script_path` | `String` | `""` | 要预加载的 JavaScript 文件路径。支持 `res://`、`user://` 等 Godot 路径。与 `preload_script` 互斥。 |
 
 ## CefTexture2D 属性
 
@@ -26,6 +28,8 @@
 | `enable_accelerated_osr` | `bool` | `true` | 在支持的平台启用加速 OSR，否则自动回退到软件渲染。 |
 | `background_color` | `Color` | `Color(0, 0, 0, 0)` | 浏览器背景色（支持透明）。 |
 | `popup_policy` | `int` | `0` | 弹窗策略：BLOCK / REDIRECT / SIGNAL_ONLY。 |
+| `preload_script` | `String` | `""` | 在 JS Bridge 注册之后、document 加载之前，为浏览器主 Frame 执行的 JavaScript 源码。与 `preload_script_path` 互斥。 |
+| `preload_script_path` | `String` | `""` | 要预加载的 JavaScript 文件路径。支持 `res://`、`user://` 等 Godot 路径。与 `preload_script` 互斥。 |
 | `texture_size` | `Vector2i` | `Vector2i(1024, 1024)` | 浏览器纹理逻辑尺寸（像素）。 |
 
 `CefTexture2D` 的 v1 版本刻意保持为仅渲染：不包含内置的 3D 表面输入映射/射线投射路由。
@@ -47,6 +51,48 @@ var mat := StandardMaterial3D.new()
 mat.albedo_texture = browser_tex
 $MeshInstance3D.set_surface_override_material(0, mat)
 ```
+
+## Preload 脚本
+
+使用 `preload_script` 或 `preload_script_path` 可以在页面 document 加载前
+执行一段由应用提供且可信的 JavaScript。Preload 会在 Godot CEF 注册内置
+JavaScript Bridge 之后执行，因此 preload 中可以使用
+`window.sendIpcMessage(...)` 等 API。
+
+请在浏览器实例创建前设置 preload 属性。对 `CefTexture` 来说，通常是在节点
+进入场景树之前，或至少在其浏览器初始化之前设置。对 `CefTexture2D` 来说，
+请在使用该资源的场景触发浏览器初始化之前设置。如果 `CefTexture` 已经放在
+场景中，请在 Inspector 中设置这些属性。
+
+```gdscript
+func _ready() -> void:
+    var browser := CefTexture.new()
+    browser.preload_script = """
+        window.appConfig = { locale: "zh-CN" };
+        window.sendIpcMessage("preload-ready");
+    """
+    browser.url = "res://ui/index.html"
+    add_child(browser)
+```
+
+脚本较大时，可以把 JavaScript 放到文件中，然后设置
+`preload_script_path`：
+
+```gdscript
+browser.preload_script_path = "res://browser/preload.js"
+browser.url = "https://example.com"
+```
+
+`preload_script` 和 `preload_script_path` 互斥。如果两者都非空，浏览器创建
+会失败并输出错误。如果 `preload_script_path` 无法打开，或文件内容不是
+合法 UTF-8，浏览器创建也会失败。
+
+Preload 只在主 Frame 执行，不会在 iframe 中执行。
+
+::: warning 仅用于可信代码
+Preload 运行在页面的主 JavaScript world 中，适合安装应用级全局变量或接入
+IPC。它不是安全隔离边界，也不应包含不允许被页面读取的秘密信息。
+:::
 
 ## 项目设置
 


### PR DESCRIPTION
## Description

I'm writing a add-on for Godot named [godot-kirie](https://github.com/moeru-ai/godot-kirie), `godot-cef` is one of its backend, I need a preload script to inject a platform object to tell browser what platform using then it can use correct IPC API.

## Testing Performed

1. Run build `cargo xtask bundle --release`
2. Create a new project then copy add-ons folder.
3. Create a `CefTexture` node and set `preload_script` property to string `"window.test_cef_injection = { hello: \"world\" };"`.
4. Start the game.
5. Open inspector in `Chrome` and eval `window.test_cef_injection`
6. Check output: `{ hello: "world" }`

## Checklist

<!-- Mark completed items with an "x" -->

- [X] I tested my changes locally
- [X] I updated docs/tests if needed
- [ ] CI passes (or I explained why it does not)
