### PR TITLE
feat: NVIDIA Linux accelerated OSR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For comprehensive API documentation, examples, and guides, visit the [full docum
 
 1. **Windows DirectX 12**: Requires at least Godot 4.6 beta 2. Godot 4.5.1 contains a bug where `RenderingDevice.get_driver_resource` on DirectX 12 textures always returns 0.
 
-2. **Vulkan Backends**: See [#4](https://github.com/dsh0416/godot-cef/issues/4) for details. On Windows and Linux, we use hooking to inject extensions for GPU-accelerated rendering (x86_64 only). This is a workaround until [godotengine/godot-proposals#13969](https://github.com/godotengine/godot-proposals/issues/13969) is resolved.
+2. **Vulkan Backends**: See [#4](https://github.com/dsh0416/godot-cef/issues/4) for details. On Windows and Linux, we use hooking to inject extensions for GPU-accelerated rendering (x86_64 only). This is a workaround until [godotengine/godot-proposals#13969](https://github.com/godotengine/godot-proposals/issues/13969) is resolved. On Linux with NVIDIA proprietary drivers, DMA-BUF acceleration requires the `nvidia-drm.modeset=1` kernel parameter; see the [Vulkan support guide](https://godotcef.org/api/vulkan-support.html#linux-nvidia-driver-requirement) for GRUB setup steps.
 
 3. **Software Rendering**: On platforms where accelerated rendering is not yet implemented, the extension automatically falls back to software rendering using CPU-based frame buffers.
 

--- a/crates/cef_app/src/lib.rs
+++ b/crates/cef_app/src/lib.rs
@@ -68,7 +68,6 @@ wrap_app! {
 
             #[cfg(target_os = "linux")]
             if self.app.godot_backend() == GodotRenderBackend::Vulkan {
-                command_line.append_switch_with_value(Some(&"ozone-platform".into()), Some(&"x11".into()));
                 command_line.append_switch_with_value(
                     Some(&"enable-features".into()),
                     Some(&"Vulkan,VulkanFromANGLE,DefaultANGLEVulkan".into()),

--- a/crates/cef_app/src/lib.rs
+++ b/crates/cef_app/src/lib.rs
@@ -66,6 +66,15 @@ wrap_app! {
             command_line.append_switch(Some(&"off-screen-rendering-enabled".into()));
             command_line.append_switch(Some(&"use-views".into()));
 
+            #[cfg(target_os = "linux")]
+            if self.app.godot_backend() == GodotRenderBackend::Vulkan {
+                command_line.append_switch_with_value(Some(&"ozone-platform".into()), Some(&"x11".into()));
+                command_line.append_switch_with_value(
+                    Some(&"enable-features".into()),
+                    Some(&"Vulkan,VulkanFromANGLE,DefaultANGLEVulkan".into()),
+                );
+            }
+
             // Only enable remote debugging in debug builds or when running from the editor
             // for security purposes. In production builds, this should be disabled.
             if self.app.enable_remote_debugging() {

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -820,6 +820,8 @@ impl VulkanTextureImporter {
         // Use the first plane's fd for memory import
         let fd = params.fds[0];
 
+        let memory_requirements = vk::MemoryRequirements::default();
+
         let mut fd_props = vk::MemoryFdPropertiesKHR::default();
         let result = unsafe {
             (self.get_memory_fd_properties)(

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -820,11 +820,6 @@ impl VulkanTextureImporter {
         // Use the first plane's fd for memory import
         let fd = params.fds[0];
 
-        let mut memory_requirements = vk::MemoryRequirements::default();
-        unsafe {
-            (fns.get_image_memory_requirements)(self.device, image, &mut memory_requirements);
-        }
-
         let mut fd_props = vk::MemoryFdPropertiesKHR::default();
         let result = unsafe {
             (self.get_memory_fd_properties)(

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -10,6 +10,7 @@ use godot::classes::rendering_device::DriverResource;
 use godot::global::{godot_error, godot_print};
 use godot::prelude::*;
 use std::collections::HashMap;
+use std::ffi::CStr;
 use std::os::fd::RawFd;
 use std::sync::Mutex;
 
@@ -76,6 +77,7 @@ pub struct VulkanTextureImporter {
     queue: vk::Queue,
     queue_family_index: u32,
     uses_separate_queue: bool,
+    src_external_queue_family: u32,
     get_memory_fd_properties: PfnVkGetMemoryFdPropertiesKHR,
     get_physical_device_image_format_properties2:
         Option<PfnVkGetPhysicalDeviceImageFormatProperties2>,
@@ -191,6 +193,23 @@ impl VulkanTextureImporter {
             );
         }
 
+        let src_external_queue_family = if Self::device_supports_extension(
+            &lib,
+            physical_device,
+            c"VK_EXT_queue_family_foreign",
+        ) {
+            godot_print!(
+                "[AcceleratedOSR/Vulkan] Using VK_QUEUE_FAMILY_FOREIGN_EXT for DMA-BUF acquire/release"
+            );
+            vk::QUEUE_FAMILY_FOREIGN_EXT
+        } else {
+            godot_print!(
+                "[AcceleratedOSR/Vulkan] VK_EXT_queue_family_foreign unavailable; \
+                 using VK_QUEUE_FAMILY_EXTERNAL for DMA-BUF acquire/release"
+            );
+            vk::QUEUE_FAMILY_EXTERNAL
+        };
+
         // Try to find a separate queue for our copy operations
         // This avoids synchronization issues with Godot's main graphics queue
         let (mut queue_family_index, mut queue_index, mut uses_separate_queue) =
@@ -295,6 +314,7 @@ impl VulkanTextureImporter {
             queue,
             queue_family_index,
             uses_separate_queue,
+            src_external_queue_family,
             fence,
             get_memory_fd_properties: fns.get_memory_fd_properties,
             get_physical_device_image_format_properties2,
@@ -310,6 +330,62 @@ impl VulkanTextureImporter {
         memory_fn_name: "vkGetMemoryFdPropertiesKHR",
         memory_fn_type: PfnVkGetMemoryFdPropertiesKHR
     );
+
+    fn device_supports_extension(
+        lib: &libloading::Library,
+        physical_device: vk::PhysicalDevice,
+        extension_name: &CStr,
+    ) -> bool {
+        if physical_device == vk::PhysicalDevice::null() {
+            return false;
+        }
+
+        type GetPhysicalDeviceExtensionProperties = unsafe extern "system" fn(
+            physical_device: vk::PhysicalDevice,
+            p_layer_name: *const std::ffi::c_char,
+            p_property_count: *mut u32,
+            p_properties: *mut vk::ExtensionProperties,
+        )
+            -> vk::Result;
+
+        let enumerate_extensions: GetPhysicalDeviceExtensionProperties = unsafe {
+            match lib.get(b"vkEnumerateDeviceExtensionProperties\0") {
+                Ok(f) => *f,
+                Err(_) => return false,
+            }
+        };
+
+        let mut count = 0;
+        let result = unsafe {
+            enumerate_extensions(
+                physical_device,
+                std::ptr::null(),
+                &mut count,
+                std::ptr::null_mut(),
+            )
+        };
+        if result != vk::Result::SUCCESS || count == 0 {
+            return false;
+        }
+
+        let mut properties = vec![vk::ExtensionProperties::default(); count as usize];
+        let result = unsafe {
+            enumerate_extensions(
+                physical_device,
+                std::ptr::null(),
+                &mut count,
+                properties.as_mut_ptr(),
+            )
+        };
+        if result != vk::Result::SUCCESS {
+            return false;
+        }
+
+        properties.iter().any(|prop| {
+            let name = unsafe { CStr::from_ptr(prop.extension_name.as_ptr()) };
+            name == extension_name
+        })
+    }
 
     fn get_dmabuf_inode(fd: RawFd) -> Option<u64> {
         let mut stat = unsafe { std::mem::zeroed::<libc::stat>() };
@@ -530,19 +606,48 @@ impl VulkanTextureImporter {
         let mut external_memory_info = vk::ExternalMemoryImageCreateInfo::default()
             .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
 
-        // Build plane layouts for DRM format modifier
+        // Build plane layouts for DRM format modifier. Some drivers reject or
+        // silently mishandle zero-sized plane layouts, so provide conservative
+        // byte sizes from CEF's stride/offset metadata.
         let plane_layouts: Vec<vk::SubresourceLayout> = params
             .fds
             .iter()
             .enumerate()
-            .map(|(i, _)| vk::SubresourceLayout {
-                offset: params.offsets.get(i).copied().unwrap_or(0),
-                size: 0, // Calculated by driver
-                row_pitch: params.strides.get(i).copied().unwrap_or(0) as u64,
-                array_pitch: 0,
-                depth_pitch: 0,
+            .map(|(i, _)| {
+                let offset = params.offsets.get(i).copied().unwrap_or(0);
+                let row_pitch = params.strides.get(i).copied().unwrap_or(0) as u64;
+                let next_offset = params
+                    .offsets
+                    .iter()
+                    .copied()
+                    .filter(|candidate| *candidate > offset)
+                    .min();
+                let size = next_offset
+                    .map(|next| next.saturating_sub(offset))
+                    .unwrap_or_else(|| row_pitch.saturating_mul(params.height as u64));
+
+                vk::SubresourceLayout {
+                    offset,
+                    size,
+                    row_pitch,
+                    array_pitch: 0,
+                    depth_pitch: 0,
+                }
             })
             .collect();
+
+        godot_print!(
+            "[AcceleratedOSR/Vulkan] Importing DMA-BUF: format={:?}, size={}x{}, \
+             modifier=0x{:x}, planes={}, strides={:?}, offsets={:?}, plane_layouts={:?}",
+            params.format,
+            params.width,
+            params.height,
+            params.modifier,
+            params.fds.len(),
+            params.strides,
+            params.offsets,
+            plane_layouts
+        );
 
         // Set up DRM format modifier info if we have a valid modifier
         let use_drm_modifier = params.modifier != DRM_FORMAT_MOD_INVALID;
@@ -741,6 +846,17 @@ impl VulkanTextureImporter {
             )
         })?;
 
+        godot_print!(
+            "[AcceleratedOSR/Vulkan] DMA-BUF memory import: \
+             fd_memory_type_bits=0x{:x}, image_memory_type_bits=0x{:x}, \
+             selected_memory_type={}, allocation_size={}, alignment={}",
+            fd_props.memory_type_bits,
+            memory_requirements.memory_type_bits,
+            memory_type_index,
+            memory_requirements.size,
+            memory_requirements.alignment
+        );
+
         // Import the memory with the DMA-BUF fd
         // Note: The fd ownership is transferred to Vulkan upon successful import
         let mut import_info = vk::ImportMemoryFdInfoKHR::default()
@@ -800,6 +916,7 @@ impl VulkanTextureImporter {
             queue: self.queue,
             uses_separate_queue: self.uses_separate_queue,
             queue_family_index: self.queue_family_index,
+            src_external_queue_family: self.src_external_queue_family,
             reset_fences: fns.reset_fences,
             reset_command_buffer: fns.reset_command_buffer,
             begin_command_buffer: fns.begin_command_buffer,

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -11,6 +11,7 @@ use godot::global::{godot_error, godot_print};
 use godot::prelude::*;
 use std::collections::HashMap;
 use std::os::fd::RawFd;
+use std::sync::Mutex;
 
 use crate::accelerated_osr::vulkan_common::{
     VulkanCopyContext, find_memory_type_index, get_godot_gpu_device_ids_vulkan,
@@ -58,8 +59,17 @@ type PfnVkGetMemoryFdPropertiesKHR = unsafe extern "system" fn(
     p_memory_fd_properties: *mut vk::MemoryFdPropertiesKHR<'_>,
 ) -> vk::Result;
 
+type PfnVkGetPhysicalDeviceImageFormatProperties2 = unsafe extern "system" fn(
+    physical_device: vk::PhysicalDevice,
+    p_image_format_info: *const vk::PhysicalDeviceImageFormatInfo2<'_>,
+    p_image_format_properties: *mut vk::ImageFormatProperties2<'_>,
+) -> vk::Result;
+
+static QUEUE_SUBMIT_LOCK: Mutex<()> = Mutex::new(());
+
 pub struct VulkanTextureImporter {
     device: vk::Device,
+    physical_device: vk::PhysicalDevice,
     command_pool: vk::CommandPool,
     command_buffer: vk::CommandBuffer,
     fence: vk::Fence,
@@ -67,7 +77,8 @@ pub struct VulkanTextureImporter {
     queue_family_index: u32,
     uses_separate_queue: bool,
     get_memory_fd_properties: PfnVkGetMemoryFdPropertiesKHR,
-    cached_memory_type_index: Option<u32>,
+    get_physical_device_image_format_properties2:
+        Option<PfnVkGetPhysicalDeviceImageFormatProperties2>,
     cache: HashMap<u64, ImportedVulkanImage>,
     frame_count: u64,
     pending_copy: Option<PendingLinuxCopy>,
@@ -88,6 +99,7 @@ struct VulkanFunctions {
     allocate_memory: vk::PFN_vkAllocateMemory,
     bind_image_memory: vk::PFN_vkBindImageMemory,
     create_image: vk::PFN_vkCreateImage,
+    get_image_memory_requirements: vk::PFN_vkGetImageMemoryRequirements,
     create_command_pool: vk::PFN_vkCreateCommandPool,
     destroy_command_pool: vk::PFN_vkDestroyCommandPool,
     allocate_command_buffers: vk::PFN_vkAllocateCommandBuffers,
@@ -164,6 +176,20 @@ impl VulkanTextureImporter {
         } else {
             vk::PhysicalDevice::null()
         };
+
+        let get_physical_device_image_format_properties2 = unsafe {
+            lib.get::<PfnVkGetPhysicalDeviceImageFormatProperties2>(
+                b"vkGetPhysicalDeviceImageFormatProperties2\0",
+            )
+            .map(|f| *f)
+            .ok()
+        };
+        if get_physical_device_image_format_properties2.is_none() {
+            godot_print!(
+                "[AcceleratedOSR/Vulkan] vkGetPhysicalDeviceImageFormatProperties2 unavailable; \
+                 DMA-BUF image format probing disabled"
+            );
+        }
 
         // Try to find a separate queue for our copy operations
         // This avoids synchronization issues with Godot's main graphics queue
@@ -263,6 +289,7 @@ impl VulkanTextureImporter {
 
         Some(Self {
             device,
+            physical_device,
             command_pool,
             command_buffer,
             queue,
@@ -270,7 +297,7 @@ impl VulkanTextureImporter {
             uses_separate_queue,
             fence,
             get_memory_fd_properties: fns.get_memory_fd_properties,
-            cached_memory_type_index: None,
+            get_physical_device_image_format_properties2,
             cache: HashMap::new(),
             frame_count: 0,
             pending_copy: None,
@@ -530,6 +557,8 @@ impl VulkanTextureImporter {
             vk::ImageTiling::LINEAR
         };
 
+        self.probe_external_image_support(params, tiling)?;
+
         let mut image_info = vk::ImageCreateInfo::default()
             .push_next(&mut external_memory_info)
             .image_type(vk::ImageType::TYPE_2D)
@@ -582,6 +611,99 @@ impl VulkanTextureImporter {
         })
     }
 
+    fn probe_external_image_support(
+        &self,
+        params: &DmaBufImportParams,
+        tiling: vk::ImageTiling,
+    ) -> Result<(), String> {
+        let Some(get_image_format_properties2) = self.get_physical_device_image_format_properties2
+        else {
+            return Ok(());
+        };
+        if self.physical_device == vk::PhysicalDevice::null() {
+            return Ok(());
+        }
+
+        let mut external_info = vk::PhysicalDeviceExternalImageFormatInfo::default()
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let mut modifier_info = vk::PhysicalDeviceImageDrmFormatModifierInfoEXT::default()
+            .drm_format_modifier(params.modifier)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+
+        let mut format_info = vk::PhysicalDeviceImageFormatInfo2::default()
+            .format(params.format)
+            .ty(vk::ImageType::TYPE_2D)
+            .tiling(tiling)
+            .usage(vk::ImageUsageFlags::TRANSFER_SRC)
+            .flags(vk::ImageCreateFlags::empty())
+            .push_next(&mut external_info);
+
+        if tiling == vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT {
+            format_info = format_info.push_next(&mut modifier_info);
+        }
+
+        let mut external_props = vk::ExternalImageFormatProperties::default();
+        let mut format_props = vk::ImageFormatProperties2::default();
+        format_props.p_next = &mut external_props as *mut _ as *mut _;
+
+        let result = unsafe {
+            get_image_format_properties2(self.physical_device, &format_info, &mut format_props)
+        };
+        if result != vk::Result::SUCCESS {
+            return Err(format!(
+                "DMA-BUF image format is unsupported before import: {:?} \
+                 (format={:?}, tiling={:?}, modifier=0x{:x}, usage={:?})",
+                result,
+                params.format,
+                tiling,
+                params.modifier,
+                vk::ImageUsageFlags::TRANSFER_SRC
+            ));
+        }
+
+        let external_memory = external_props.external_memory_properties;
+        if !external_memory
+            .external_memory_features
+            .contains(vk::ExternalMemoryFeatureFlags::IMPORTABLE)
+        {
+            return Err(format!(
+                "DMA-BUF image format is not importable \
+                 (format={:?}, tiling={:?}, modifier=0x{:x}, features={:?}, compatible={:?})",
+                params.format,
+                tiling,
+                params.modifier,
+                external_memory.external_memory_features,
+                external_memory.compatible_handle_types
+            ));
+        }
+
+        if !external_memory
+            .compatible_handle_types
+            .contains(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+        {
+            return Err(format!(
+                "DMA-BUF handle type is not compatible with image format \
+                 (format={:?}, tiling={:?}, modifier=0x{:x}, compatible={:?})",
+                params.format, tiling, params.modifier, external_memory.compatible_handle_types
+            ));
+        }
+
+        godot_print!(
+            "[AcceleratedOSR/Vulkan] DMA-BUF image format probe OK: format={:?}, \
+             tiling={:?}, modifier=0x{:x}, max_extent={}x{}, features={:?}, compatible={:?}",
+            params.format,
+            tiling,
+            params.modifier,
+            format_props.image_format_properties.max_extent.width,
+            format_props.image_format_properties.max_extent.height,
+            external_memory.external_memory_features,
+            external_memory.compatible_handle_types
+        );
+
+        Ok(())
+    }
+
     fn import_memory_for_dmabuf(
         &mut self,
         params: &mut DmaBufImportParams,
@@ -592,29 +714,32 @@ impl VulkanTextureImporter {
         // Use the first plane's fd for memory import
         let fd = params.fds[0];
 
-        // Get or cache the memory type index (same for all DMA-BUF imports)
-        let memory_type_index = if let Some(cached) = self.cached_memory_type_index {
-            cached
-        } else {
-            // Query memory properties for this fd (only once)
-            let mut fd_props = vk::MemoryFdPropertiesKHR::default();
-            let result = unsafe {
-                (self.get_memory_fd_properties)(
-                    self.device,
-                    vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT,
-                    fd,
-                    &mut fd_props,
-                )
-            };
-            if result != vk::Result::SUCCESS {
-                return Err(format!("Failed to get memory fd properties: {:?}", result));
-            }
+        let mut memory_requirements = vk::MemoryRequirements::default();
+        unsafe {
+            (fns.get_image_memory_requirements)(self.device, image, &mut memory_requirements);
+        }
 
-            let idx = find_memory_type_index(fd_props.memory_type_bits)
-                .ok_or("Failed to find suitable memory type")?;
-            self.cached_memory_type_index = Some(idx);
-            idx
+        let mut fd_props = vk::MemoryFdPropertiesKHR::default();
+        let result = unsafe {
+            (self.get_memory_fd_properties)(
+                self.device,
+                vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT,
+                fd,
+                &mut fd_props,
+            )
         };
+        if result != vk::Result::SUCCESS {
+            return Err(format!("Failed to get memory fd properties: {:?}", result));
+        }
+
+        let memory_type_bits = fd_props.memory_type_bits & memory_requirements.memory_type_bits;
+        let memory_type_index = find_memory_type_index(memory_type_bits).ok_or_else(|| {
+            format!(
+                "Failed to find suitable DMA-BUF memory type \
+                 (fd_memory_type_bits=0x{:x}, image_memory_type_bits=0x{:x})",
+                fd_props.memory_type_bits, memory_requirements.memory_type_bits
+            )
+        })?;
 
         // Import the memory with the DMA-BUF fd
         // Note: The fd ownership is transferred to Vulkan upon successful import
@@ -624,12 +749,10 @@ impl VulkanTextureImporter {
 
         let mut dedicated_info = vk::MemoryDedicatedAllocateInfo::default().image(image);
 
-        let allocation_size = (params.width as u64) * (params.height as u64) * 4;
-
         let alloc_info = vk::MemoryAllocateInfo::default()
             .push_next(&mut import_info)
             .push_next(&mut dedicated_info)
-            .allocation_size(allocation_size)
+            .allocation_size(memory_requirements.size)
             .memory_type_index(memory_type_index);
 
         let mut memory = vk::DeviceMemory::null();
@@ -637,7 +760,17 @@ impl VulkanTextureImporter {
             (fns.allocate_memory)(self.device, &alloc_info, std::ptr::null(), &mut memory)
         };
         if result != vk::Result::SUCCESS {
-            return Err(format!("Failed to allocate/import memory: {:?}", result));
+            return Err(format!(
+                "Failed to allocate/import DMA-BUF memory: {:?} \
+                 (fd_memory_type_bits=0x{:x}, image_memory_type_bits=0x{:x}, \
+                 memory_type_index={}, allocation_size={}, alignment={})",
+                result,
+                fd_props.memory_type_bits,
+                memory_requirements.memory_type_bits,
+                memory_type_index,
+                memory_requirements.size,
+                memory_requirements.alignment
+            ));
         }
 
         params.fds[0] = -1;
@@ -675,6 +808,10 @@ impl VulkanTextureImporter {
             cmd_copy_image: fns.cmd_copy_image,
             queue_submit: fns.queue_submit,
         };
+
+        let _queue_guard = QUEUE_SUBMIT_LOCK
+            .lock()
+            .map_err(|_| "Vulkan queue submit lock was poisoned".to_string())?;
         submit_vulkan_copy_async(
             &ctx,
             self.command_buffer,

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -101,7 +101,6 @@ struct VulkanFunctions {
     allocate_memory: vk::PFN_vkAllocateMemory,
     bind_image_memory: vk::PFN_vkBindImageMemory,
     create_image: vk::PFN_vkCreateImage,
-    get_image_memory_requirements: vk::PFN_vkGetImageMemoryRequirements,
     create_command_pool: vk::PFN_vkCreateCommandPool,
     destroy_command_pool: vk::PFN_vkDestroyCommandPool,
     allocate_command_buffers: vk::PFN_vkAllocateCommandBuffers,

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -750,8 +750,10 @@ impl VulkanTextureImporter {
         }
 
         let mut external_props = vk::ExternalImageFormatProperties::default();
-        let mut format_props = vk::ImageFormatProperties2::default();
-        format_props.p_next = &mut external_props as *mut _ as *mut _;
+        let mut format_props = vk::ImageFormatProperties2 {
+            p_next: &mut external_props as *mut _ as *mut _,
+            ..Default::default()
+        };
 
         let result = unsafe {
             get_image_format_properties2(self.physical_device, &format_info, &mut format_props)

--- a/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/linux/vulkan.rs
@@ -635,18 +635,20 @@ impl VulkanTextureImporter {
             })
             .collect();
 
-        godot_print!(
-            "[AcceleratedOSR/Vulkan] Importing DMA-BUF: format={:?}, size={}x{}, \
-             modifier=0x{:x}, planes={}, strides={:?}, offsets={:?}, plane_layouts={:?}",
-            params.format,
-            params.width,
-            params.height,
-            params.modifier,
-            params.fds.len(),
-            params.strides,
-            params.offsets,
-            plane_layouts
-        );
+        if cfg!(debug_assertions) {
+            godot_print!(
+                "[AcceleratedOSR/Vulkan] Importing DMA-BUF: format={:?}, size={}x{}, \
+                 modifier=0x{:x}, planes={}, strides={:?}, offsets={:?}, plane_layouts={:?}",
+                params.format,
+                params.width,
+                params.height,
+                params.modifier,
+                params.fds.len(),
+                params.strides,
+                params.offsets,
+                plane_layouts
+            );
+        }
 
         // Set up DRM format modifier info if we have a valid modifier
         let use_drm_modifier = params.modifier != DRM_FORMAT_MOD_INVALID;
@@ -845,16 +847,19 @@ impl VulkanTextureImporter {
             )
         })?;
 
-        godot_print!(
-            "[AcceleratedOSR/Vulkan] DMA-BUF memory import: \
-             fd_memory_type_bits=0x{:x}, image_memory_type_bits=0x{:x}, \
-             selected_memory_type={}, allocation_size={}, alignment={}",
-            fd_props.memory_type_bits,
-            memory_requirements.memory_type_bits,
-            memory_type_index,
-            memory_requirements.size,
-            memory_requirements.alignment
-        );
+        #[cfg(debug_assertions)]
+        {
+            godot_print!(
+                "[AcceleratedOSR/Vulkan] DMA-BUF memory import: \
+                 fd_memory_type_bits=0x{:x}, image_memory_type_bits=0x{:x}, \
+                 selected_memory_type={}, allocation_size={}, alignment={}",
+                fd_props.memory_type_bits,
+                memory_requirements.memory_type_bits,
+                memory_type_index,
+                memory_requirements.size,
+                memory_requirements.alignment
+            );
+        }
 
         // Import the memory with the DMA-BUF fd
         // Note: The fd ownership is transferred to Vulkan upon successful import

--- a/crates/gdcef/src/accelerated_osr/vulkan_common.rs
+++ b/crates/gdcef/src/accelerated_osr/vulkan_common.rs
@@ -40,10 +40,6 @@ macro_rules! impl_vulkan_common_methods {
                     ash::vk::PFN_vkBindImageMemory
                 ),
                 create_image: load_device_fn!("vkCreateImage", ash::vk::PFN_vkCreateImage),
-                get_image_memory_requirements: load_device_fn!(
-                    "vkGetImageMemoryRequirements",
-                    ash::vk::PFN_vkGetImageMemoryRequirements
-                ),
                 create_command_pool: load_device_fn!(
                     "vkCreateCommandPool",
                     ash::vk::PFN_vkCreateCommandPool

--- a/crates/gdcef/src/accelerated_osr/vulkan_common.rs
+++ b/crates/gdcef/src/accelerated_osr/vulkan_common.rs
@@ -40,6 +40,10 @@ macro_rules! impl_vulkan_common_methods {
                     ash::vk::PFN_vkBindImageMemory
                 ),
                 create_image: load_device_fn!("vkCreateImage", ash::vk::PFN_vkCreateImage),
+                get_image_memory_requirements: load_device_fn!(
+                    "vkGetImageMemoryRequirements",
+                    ash::vk::PFN_vkGetImageMemoryRequirements
+                ),
                 create_command_pool: load_device_fn!(
                     "vkCreateCommandPool",
                     ash::vk::PFN_vkCreateCommandPool

--- a/crates/gdcef/src/accelerated_osr/vulkan_common.rs
+++ b/crates/gdcef/src/accelerated_osr/vulkan_common.rs
@@ -205,12 +205,29 @@ pub(crate) fn submit_vulkan_copy_async(
         layer_count: 1,
     };
 
+    let source_from_external_queue = ctx.src_external_queue_family != vk::QUEUE_FAMILY_IGNORED;
+    let src_old_layout = if source_from_external_queue {
+        vk::ImageLayout::GENERAL
+    } else {
+        vk::ImageLayout::UNDEFINED
+    };
+    let src_src_queue_family = if source_from_external_queue {
+        ctx.src_external_queue_family
+    } else {
+        vk::QUEUE_FAMILY_IGNORED
+    };
+    let src_dst_queue_family = if source_from_external_queue {
+        ctx.queue_family_index
+    } else {
+        vk::QUEUE_FAMILY_IGNORED
+    };
+
     let barriers = [
         vk::ImageMemoryBarrier::default()
-            .old_layout(vk::ImageLayout::UNDEFINED)
+            .old_layout(src_old_layout)
             .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .src_queue_family_index(src_src_queue_family)
+            .dst_queue_family_index(src_dst_queue_family)
             .image(src)
             .subresource_range(subresource_range)
             .src_access_mask(vk::AccessFlags::empty())
@@ -271,6 +288,33 @@ pub(crate) fn submit_vulkan_copy_async(
         );
     }
 
+    if source_from_external_queue {
+        let source_release_barrier = vk::ImageMemoryBarrier::default()
+            .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+            .new_layout(vk::ImageLayout::GENERAL)
+            .src_queue_family_index(ctx.queue_family_index)
+            .dst_queue_family_index(ctx.src_external_queue_family)
+            .image(src)
+            .subresource_range(subresource_range)
+            .src_access_mask(vk::AccessFlags::TRANSFER_READ)
+            .dst_access_mask(vk::AccessFlags::empty());
+
+        unsafe {
+            (ctx.cmd_pipeline_barrier)(
+                cmd_buffer,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+                vk::DependencyFlags::empty(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                1,
+                &source_release_barrier,
+            );
+        }
+    }
+
     let (src_family, dst_family) = if ctx.uses_separate_queue && ctx.queue_family_index != 0 {
         (ctx.queue_family_index, 0u32)
     } else {
@@ -320,6 +364,7 @@ pub(crate) struct VulkanCopyContext {
     pub queue: ash::vk::Queue,
     pub uses_separate_queue: bool,
     pub queue_family_index: u32,
+    pub src_external_queue_family: u32,
     // Function pointers
     pub reset_fences: ash::vk::PFN_vkResetFences,
     pub reset_command_buffer: ash::vk::PFN_vkResetCommandBuffer,

--- a/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
@@ -71,6 +71,7 @@ struct VulkanFunctions {
     allocate_memory: vk::PFN_vkAllocateMemory,
     bind_image_memory: vk::PFN_vkBindImageMemory,
     create_image: vk::PFN_vkCreateImage,
+    get_image_memory_requirements: vk::PFN_vkGetImageMemoryRequirements,
     create_command_pool: vk::PFN_vkCreateCommandPool,
     destroy_command_pool: vk::PFN_vkDestroyCommandPool,
     allocate_command_buffers: vk::PFN_vkAllocateCommandBuffers,

--- a/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
@@ -71,7 +71,6 @@ struct VulkanFunctions {
     allocate_memory: vk::PFN_vkAllocateMemory,
     bind_image_memory: vk::PFN_vkBindImageMemory,
     create_image: vk::PFN_vkCreateImage,
-    get_image_memory_requirements: vk::PFN_vkGetImageMemoryRequirements,
     create_command_pool: vk::PFN_vkCreateCommandPool,
     destroy_command_pool: vk::PFN_vkDestroyCommandPool,
     allocate_command_buffers: vk::PFN_vkAllocateCommandBuffers,

--- a/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
+++ b/crates/gdcef/src/accelerated_osr/windows/vulkan.rs
@@ -584,6 +584,7 @@ impl VulkanTextureImporter {
             queue: self.queue,
             uses_separate_queue: self.uses_separate_queue,
             queue_family_index: self.queue_family_index,
+            src_external_queue_family: vk::QUEUE_FAMILY_IGNORED,
             reset_fences: fns.reset_fences,
             reset_command_buffer: fns.reset_command_buffer,
             begin_command_buffer: fns.begin_command_buffer,

--- a/crates/gdcef/src/vulkan_hook/linux.rs
+++ b/crates/gdcef/src/vulkan_hook/linux.rs
@@ -11,6 +11,7 @@ const VK_KHR_EXTERNAL_MEMORY_NAME: &CStr = c"VK_KHR_external_memory";
 const VK_KHR_EXTERNAL_MEMORY_FD_NAME: &CStr = c"VK_KHR_external_memory_fd";
 const VK_EXT_EXTERNAL_MEMORY_DMA_BUF_NAME: &CStr = c"VK_EXT_external_memory_dma_buf";
 const VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME: &CStr = c"VK_EXT_image_drm_format_modifier";
+const VK_EXT_QUEUE_FAMILY_FOREIGN_NAME: &CStr = c"VK_EXT_queue_family_foreign";
 
 define_vulkan_hook!(
     log_prefix: "[VulkanHook/Linux]",
@@ -20,6 +21,7 @@ define_vulkan_hook!(
         VK_KHR_EXTERNAL_MEMORY_NAME,
         VK_KHR_EXTERNAL_MEMORY_FD_NAME,
         VK_EXT_EXTERNAL_MEMORY_DMA_BUF_NAME,
-        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME
+        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME,
+        VK_EXT_QUEUE_FAMILY_FOREIGN_NAME
     ]
 );

--- a/crates/gdcef/src/vulkan_hook/linux.rs
+++ b/crates/gdcef/src/vulkan_hook/linux.rs
@@ -10,6 +10,7 @@ use super::common::define_vulkan_hook;
 const VK_KHR_EXTERNAL_MEMORY_NAME: &CStr = c"VK_KHR_external_memory";
 const VK_KHR_EXTERNAL_MEMORY_FD_NAME: &CStr = c"VK_KHR_external_memory_fd";
 const VK_EXT_EXTERNAL_MEMORY_DMA_BUF_NAME: &CStr = c"VK_EXT_external_memory_dma_buf";
+const VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME: &CStr = c"VK_EXT_image_drm_format_modifier";
 
 define_vulkan_hook!(
     log_prefix: "[VulkanHook/Linux]",
@@ -18,6 +19,7 @@ define_vulkan_hook!(
     required_extensions: [
         VK_KHR_EXTERNAL_MEMORY_NAME,
         VK_KHR_EXTERNAL_MEMORY_FD_NAME,
-        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_NAME
+        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_NAME,
+        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME
     ]
 );

--- a/docs/api/vulkan-support.md
+++ b/docs/api/vulkan-support.md
@@ -43,6 +43,47 @@ Since Godot doesn't provide an API to request additional Vulkan extensions durin
 - `VK_KHR_external_memory_fd` — File descriptor based sharing
 - `VK_EXT_external_memory_dma_buf` — DMA-BUF sharing for zero-copy transfers
 
+### Linux NVIDIA Driver Requirement
+
+:::: warning
+On Linux systems using NVIDIA proprietary drivers, DMA-BUF accelerated rendering requires DRM kernel mode setting to be enabled with the `nvidia-drm.modeset=1` kernel parameter.
+::::
+
+Without `nvidia-drm.modeset=1`, the NVIDIA driver may not expose the DMA-BUF path needed for zero-copy texture sharing between CEF and Godot. Configure this kernel parameter through your distribution's bootloader or modprobe configuration, then reboot before using accelerated OSR.
+
+For GRUB-based systems, edit `/etc/default/grub` and add `nvidia-drm.modeset=1` to the kernel command line:
+
+```bash
+sudo "${EDITOR:-nano}" /etc/default/grub
+```
+
+For example:
+
+```ini
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvidia-drm.modeset=1"
+```
+
+Keep any existing kernel parameters in the quoted value and append `nvidia-drm.modeset=1` separated by a space. Then regenerate the GRUB configuration:
+
+```bash
+# Debian/Ubuntu
+sudo update-grub
+
+# Fedora/RHEL
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# Arch Linux
+sudo grub-mkconfig -o /boot/grub/grub.cfg
+```
+
+Reboot after updating GRUB. You can verify the NVIDIA DRM modeset state with:
+
+```bash
+cat /sys/module/nvidia_drm/parameters/modeset
+```
+
+The expected output is `Y`. If your system uses another bootloader, such as systemd-boot or rEFInd, add `nvidia-drm.modeset=1` to that bootloader's kernel command line instead.
+
 ## Multi-GPU Support
 
 On systems with multiple GPUs (e.g., laptops with integrated + discrete graphics), **CEF must use the same GPU as Godot** for texture sharing to work. This is handled via command-line switches (`--gpu-vendor-id` and `--gpu-device-id`) passed to CEF subprocesses.

--- a/docs/api/vulkan-support.md
+++ b/docs/api/vulkan-support.md
@@ -45,9 +45,9 @@ Since Godot doesn't provide an API to request additional Vulkan extensions durin
 
 ### Linux NVIDIA Driver Requirement
 
-:::: warning
+::: warning
 On Linux systems using NVIDIA proprietary drivers, DMA-BUF accelerated rendering requires DRM kernel mode setting to be enabled with the `nvidia-drm.modeset=1` kernel parameter.
-::::
+:::
 
 Without `nvidia-drm.modeset=1`, the NVIDIA driver may not expose the DMA-BUF path needed for zero-copy texture sharing between CEF and Godot. Configure this kernel parameter through your distribution's bootloader or modprobe configuration, then reboot before using accelerated OSR.
 

--- a/docs/zh_CN/api/vulkan-support.md
+++ b/docs/zh_CN/api/vulkan-support.md
@@ -43,6 +43,47 @@ CEF 中的 GPU 加速离屏渲染（OSR）需要在 CEF 渲染器进程和宿主
 - `VK_KHR_external_memory_fd` — 基于文件描述符的共享
 - `VK_EXT_external_memory_dma_buf` — DMA-BUF 共享用于零拷贝传输
 
+### Linux NVIDIA 驱动要求
+
+:::: warning
+在使用 NVIDIA 专有驱动的 Linux 系统上，DMA-BUF 加速渲染需要通过 `nvidia-drm.modeset=1` 内核参数启用 DRM 内核模式设置。
+::::
+
+如果没有 `nvidia-drm.modeset=1`，NVIDIA 驱动可能不会暴露 CEF 与 Godot 之间零拷贝纹理共享所需的 DMA-BUF 路径。请通过发行版的引导加载器或 modprobe 配置设置该内核参数，然后重启再使用加速 OSR。
+
+对于基于 GRUB 的系统，编辑 `/etc/default/grub`，并将 `nvidia-drm.modeset=1` 添加到内核命令行：
+
+```bash
+sudo "${EDITOR:-nano}" /etc/default/grub
+```
+
+例如：
+
+```ini
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvidia-drm.modeset=1"
+```
+
+请保留引号中已有的内核参数，并用空格追加 `nvidia-drm.modeset=1`。然后重新生成 GRUB 配置：
+
+```bash
+# Debian/Ubuntu
+sudo update-grub
+
+# Fedora/RHEL
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# Arch Linux
+sudo grub-mkconfig -o /boot/grub/grub.cfg
+```
+
+更新 GRUB 后需要重启。可以用以下命令确认 NVIDIA DRM modeset 状态：
+
+```bash
+cat /sys/module/nvidia_drm/parameters/modeset
+```
+
+期望输出为 `Y`。如果您的系统使用 systemd-boot 或 rEFInd 等其他引导加载器，请改为将 `nvidia-drm.modeset=1` 添加到对应引导加载器的内核命令行中。
+
 ## 多 GPU 支持
 
 在具有多个 GPU 的系统上（例如笔记本电脑的集成显卡 + 独立显卡），**CEF 必须使用与 Godot 相同的 GPU** 才能使纹理共享工作。这通过传递给 CEF 子进程的命令行开关（`--gpu-vendor-id` 和 `--gpu-device-id`）处理。

--- a/docs/zh_CN/api/vulkan-support.md
+++ b/docs/zh_CN/api/vulkan-support.md
@@ -45,9 +45,9 @@ CEF 中的 GPU 加速离屏渲染（OSR）需要在 CEF 渲染器进程和宿主
 
 ### Linux NVIDIA 驱动要求
 
-:::: warning
+::: warning
 在使用 NVIDIA 专有驱动的 Linux 系统上，DMA-BUF 加速渲染需要通过 `nvidia-drm.modeset=1` 内核参数启用 DRM 内核模式设置。
-::::
+:::
 
 如果没有 `nvidia-drm.modeset=1`，NVIDIA 驱动可能不会暴露 CEF 与 Godot 之间零拷贝纹理共享所需的 DMA-BUF 路径。请通过发行版的引导加载器或 modprobe 配置设置该内核参数，然后重启再使用加速 OSR。
 


### PR DESCRIPTION
## Description

Fix Linux Vulkan accelerated OSR on NVIDIA proprietary drivers by addressing the full DMA-BUF import path: CEF Vulkan feature selection, required Vulkan extensions, DRM format modifier handling, memory allocation requirements, and external queue ownership transfer.

This makes the Linux Vulkan DMA-BUF path work more reliably on NVIDIA, while documenting the required `nvidia-drm.modeset=1` kernel parameter.

Before this patch, the Linux OSR support has already been working on Intel and AMD GPUs.

## Related Issues

Related to #4
Fixes #162

## Changes Made

- Enable CEF/ANGLE Vulkan features on Linux when Godot is using the Vulkan backend.
- Request `VK_EXT_image_drm_format_modifier` and `VK_EXT_queue_family_foreign` through the Linux Vulkan hook.
- Import DMA-BUF images with DRM modifier metadata, explicit plane layouts, and external image format probing.
- Use per-image memory requirements and compatible FD memory type bits instead of a cached memory type/allocation size.
- Add queue-family acquire/release barriers for externally owned DMA-BUF images.
- Document the NVIDIA DRM modeset requirement.

## Testing Performed

- Ran `cargo xtask bundle` successfully on Linux.
- Verified the NVIDIA DMA-BUF accelerated path with `nvidia-drm.modeset=1` enabled.

## Checklist

- [x] I tested my changes locally
- [x] I updated docs/tests if needed
- [x] CI passes (or I explained why it does not)
