### PR TITLE
feat: dpi probe on gnome desktop environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "objc2-metal",
  "percent-encoding",
  "process_path",
+ "quick-xml",
  "retour",
  "software_render",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ url = "2"
 percent-encoding = "2"
 adblock = "0.12"
 ciborium = "0.2"
+quick-xml = "0.39"
 
 [workspace.lints.rust]
 unconditional_panic = "deny"

--- a/crates/gdcef/Cargo.toml
+++ b/crates/gdcef/Cargo.toml
@@ -44,6 +44,7 @@ retour = { workspace = true }
 ash = { workspace = true }
 libloading = { workspace = true }
 libc = { workspace = true }
+quick-xml = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 retour = { workspace = true }

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -57,52 +57,137 @@ pub fn get_display_scale_factor() -> f32 {
 #[cfg(target_os = "linux")]
 fn linux_desktop_scale_candidate() -> Option<f32> {
     *LINUX_DESKTOP_SCALE_CANDIDATE.get_or_init(|| {
-        let scales = gnome_monitors_xml_scales();
-        scales
-            .into_iter()
-            .filter(|scale| scale.is_finite() && *scale > 1.0)
-            .max_by(|a, b| a.total_cmp(b))
+        let scales = gnome_monitor_scales();
+        match scales.primary_scale {
+            Some(scale) if scale.is_finite() && scale > 1.0 => Some(scale),
+            Some(_) => None,
+            None => scales
+                .all_scales
+                .into_iter()
+                .filter(|scale| scale.is_finite() && *scale > 1.0)
+                .max_by(|a, b| a.total_cmp(b)),
+        }
     })
 }
 
 #[cfg(target_os = "linux")]
-fn gnome_monitors_xml_scales() -> Vec<f32> {
+#[derive(Default)]
+struct GnomeMonitorScales {
+    primary_scale: Option<f32>,
+    all_scales: Vec<f32>,
+}
+
+#[cfg(target_os = "linux")]
+fn gnome_monitor_scales() -> GnomeMonitorScales {
+    let scales = gnome_monitors_xml_scales();
+    let primary_scale = scales
+        .logical_monitors
+        .iter()
+        .find(|monitor| monitor.primary)
+        .and_then(|monitor| monitor.scale);
+    let all_scales = scales
+        .logical_monitors
+        .into_iter()
+        .filter_map(|monitor| monitor.scale)
+        .collect::<Vec<_>>();
+    GnomeMonitorScales {
+        primary_scale,
+        all_scales,
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct GnomeMonitorsXml {
+    logical_monitors: Vec<GnomeLogicalMonitor>,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct GnomeLogicalMonitor {
+    primary: bool,
+    scale: Option<f32>,
+}
+
+#[cfg(target_os = "linux")]
+enum MonitorXmlText {
+    Primary,
+    Scale,
+}
+
+#[cfg(target_os = "linux")]
+fn gnome_monitors_xml_scales() -> GnomeMonitorsXml {
     use quick_xml::Reader;
     use quick_xml::events::Event;
 
-    let Some(home) = std::env::var_os("HOME") else {
-        return Vec::new();
+    let Some(config_home) = linux_config_home() else {
+        return GnomeMonitorsXml::default();
     };
-    let path = PathBuf::from(home).join(".config/monitors.xml");
+    let path = config_home.join("monitors.xml");
     let Ok(contents) = std::fs::read_to_string(path) else {
-        return Vec::new();
+        return GnomeMonitorsXml::default();
     };
     let mut reader = Reader::from_str(&contents);
     reader.config_mut().trim_text(true);
 
-    let mut scales = Vec::new();
-    let mut in_scale = false;
+    let mut logical_monitors = Vec::new();
+    let mut current_monitor: Option<GnomeLogicalMonitor> = None;
+    let mut text_target: Option<MonitorXmlText> = None;
     loop {
         match reader.read_event() {
-            Ok(Event::Start(element)) if element.name().as_ref() == b"scale" => {
-                in_scale = true;
+            Ok(Event::Start(element)) if element.name().as_ref() == b"logicalmonitor" => {
+                current_monitor = Some(GnomeLogicalMonitor::default());
             }
-            Ok(Event::End(element)) if element.name().as_ref() == b"scale" => {
-                in_scale = false;
+            Ok(Event::End(element)) if element.name().as_ref() == b"logicalmonitor" => {
+                if let Some(monitor) = current_monitor.take() {
+                    logical_monitors.push(monitor);
+                }
+                text_target = None;
             }
-            Ok(Event::Text(text)) if in_scale => {
-                if let Ok(value) = text.decode()
-                    && let Ok(scale) = value.parse::<f32>()
+            Ok(Event::Start(element)) if current_monitor.is_some() => {
+                text_target = match element.name().as_ref() {
+                    b"primary" => Some(MonitorXmlText::Primary),
+                    b"scale" => Some(MonitorXmlText::Scale),
+                    _ => None,
+                };
+            }
+            Ok(Event::End(element)) if matches!(element.name().as_ref(), b"primary" | b"scale") => {
+                text_target = None;
+            }
+            Ok(Event::Text(text)) => {
+                if let Some(monitor) = current_monitor.as_mut()
+                    && let Some(value) = text.decode().ok()
                 {
-                    scales.push(scale);
+                    match text_target {
+                        Some(MonitorXmlText::Primary) => {
+                            let normalized = value.trim();
+                            monitor.primary =
+                                normalized == "yes" || normalized == "true" || normalized == "1";
+                        }
+                        Some(MonitorXmlText::Scale) => {
+                            if let Ok(scale) = value.parse::<f32>() {
+                                monitor.scale = Some(scale);
+                            }
+                        }
+                        None => {}
+                    }
                 }
             }
             Ok(Event::Eof) => break,
-            Err(_) => return Vec::new(),
+            Err(_) => return GnomeMonitorsXml::default(),
             _ => {}
         }
     }
-    scales
+
+    GnomeMonitorsXml { logical_monitors }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_config_home() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -17,7 +17,6 @@ static LINUX_DESKTOP_SCALE_CANDIDATE: OnceLock<Option<f32>> = OnceLock::new();
 /// and high-DPI displays. A value of `1.0` means "no scaling".
 pub fn get_display_scale_factor() -> f32 {
     let display_server = DisplayServer::singleton();
-    let screen_scale = display_server.screen_get_scale();
 
     // NOTE: `display_server.screen_get_scale` is implemented on Android, iOS,
     // Web, macOS, and Linux (Wayland). On Windows, this method always returns
@@ -32,25 +31,23 @@ pub fn get_display_scale_factor() -> f32 {
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     {
-        #[cfg(target_os = "linux")]
+        let screen_scale = display_server.screen_get_scale();
+        if screen_scale <= 1.0
+            && env_or_empty("XDG_SESSION_TYPE").eq_ignore_ascii_case("wayland")
+            && let Some(candidate) = linux_desktop_scale_candidate()
+            && candidate > 1.0
         {
-            if screen_scale <= 1.0
-                && env_or_empty("XDG_SESSION_TYPE").eq_ignore_ascii_case("wayland")
-                && let Some(candidate) = linux_desktop_scale_candidate()
-                && candidate > 1.0
-            {
-                candidate
-            } else {
-                screen_scale
-            }
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
+            candidate
+        } else {
             screen_scale
         }
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        display_server.screen_get_scale();
     }
 }
 

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -4,6 +4,10 @@ use godot::classes::Os;
 use godot::{classes::DisplayServer, obj::Singleton};
 use process_path::get_dylib_path;
 use std::path::PathBuf;
+use std::sync::OnceLock;
+
+#[cfg(target_os = "linux")]
+static LINUX_DESKTOP_SCALE_CANDIDATE: OnceLock<Option<f32>> = OnceLock::new();
 
 /// Returns the display scale factor for the primary screen.
 ///
@@ -12,6 +16,7 @@ use std::path::PathBuf;
 /// and high-DPI displays. A value of `1.0` means "no scaling".
 pub fn get_display_scale_factor() -> f32 {
     let display_server = DisplayServer::singleton();
+    let screen_scale = display_server.screen_get_scale();
 
     // NOTE: `display_server.screen_get_scale` is implemented on Android, iOS,
     // Web, macOS, and Linux (Wayland). On Windows, this method always returns
@@ -28,8 +33,65 @@ pub fn get_display_scale_factor() -> f32 {
 
     #[cfg(not(target_os = "windows"))]
     {
-        display_server.screen_get_scale()
+        #[cfg(target_os = "linux")]
+        {
+            if screen_scale <= 1.0
+                && env_or_empty("XDG_SESSION_TYPE").eq_ignore_ascii_case("wayland")
+                && let Some(candidate) = linux_desktop_scale_candidate()
+                && candidate > 1.0
+            {
+                return candidate;
+            } else {
+                return screen_scale;
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            screen_scale
+        }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_desktop_scale_candidate() -> Option<f32> {
+    *LINUX_DESKTOP_SCALE_CANDIDATE.get_or_init(|| {
+        let scales = gnome_monitors_xml_scales();
+        scales
+            .into_iter()
+            .filter(|scale| scale.is_finite() && *scale > 1.0)
+            .max_by(|a, b| a.total_cmp(b))
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn gnome_monitors_xml_scales() -> Vec<f32> {
+    let Some(home) = std::env::var_os("HOME") else {
+        return Vec::new();
+    };
+    let path = PathBuf::from(home).join(".config/monitors.xml");
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut scales = Vec::new();
+    let mut rest = contents.as_str();
+    while let Some(start) = rest.find("<scale>") {
+        rest = &rest[start + "<scale>".len()..];
+        let Some(end) = rest.find("</scale>") else {
+            break;
+        };
+        let value = rest[..end].trim();
+        if let Ok(scale) = value.parse::<f32>() {
+            scales.push(scale);
+        }
+        rest = &rest[end + "</scale>".len()..];
+    }
+    scales
+}
+
+#[cfg(target_os = "linux")]
+fn env_or_empty(name: &str) -> String {
+    std::env::var(name).unwrap_or_default()
 }
 
 fn get_dylib_path_checked() -> CefResult<PathBuf> {

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -66,6 +66,9 @@ fn linux_desktop_scale_candidate() -> Option<f32> {
 
 #[cfg(target_os = "linux")]
 fn gnome_monitors_xml_scales() -> Vec<f32> {
+    use quick_xml::Reader;
+    use quick_xml::events::Event;
+
     let Some(home) = std::env::var_os("HOME") else {
         return Vec::new();
     };
@@ -73,18 +76,30 @@ fn gnome_monitors_xml_scales() -> Vec<f32> {
     let Ok(contents) = std::fs::read_to_string(path) else {
         return Vec::new();
     };
+    let mut reader = Reader::from_str(&contents);
+    reader.config_mut().trim_text(true);
+
     let mut scales = Vec::new();
-    let mut rest = contents.as_str();
-    while let Some(start) = rest.find("<scale>") {
-        rest = &rest[start + "<scale>".len()..];
-        let Some(end) = rest.find("</scale>") else {
-            break;
-        };
-        let value = rest[..end].trim();
-        if let Ok(scale) = value.parse::<f32>() {
-            scales.push(scale);
+    let mut in_scale = false;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) if element.name().as_ref() == b"scale" => {
+                in_scale = true;
+            }
+            Ok(Event::End(element)) if element.name().as_ref() == b"scale" => {
+                in_scale = false;
+            }
+            Ok(Event::Text(text)) if in_scale => {
+                if let Ok(value) = text.decode()
+                    && let Ok(scale) = value.parse::<f32>()
+                {
+                    scales.push(scale);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => return Vec::new(),
+            _ => {}
         }
-        rest = &rest[end + "</scale>".len()..];
     }
     scales
 }

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -47,7 +47,7 @@ pub fn get_display_scale_factor() -> f32 {
 
     #[cfg(not(any(target_os = "windows", target_os = "linux")))]
     {
-        display_server.screen_get_scale();
+        display_server.screen_get_scale()
     }
 }
 

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -40,9 +40,9 @@ pub fn get_display_scale_factor() -> f32 {
                 && let Some(candidate) = linux_desktop_scale_candidate()
                 && candidate > 1.0
             {
-                return candidate;
+                candidate
             } else {
-                return screen_scale;
+                screen_scale
             }
         }
 

--- a/crates/gdcef/src/utils.rs
+++ b/crates/gdcef/src/utils.rs
@@ -4,6 +4,7 @@ use godot::classes::Os;
 use godot::{classes::DisplayServer, obj::Singleton};
 use process_path::get_dylib_path;
 use std::path::PathBuf;
+#[cfg(target_os = "linux")]
 use std::sync::OnceLock;
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Add a Linux Wayland DPI fallback that reads GNOME `monitors.xml` when Godot reports `screen_get_scale() == 1.0`.

Fixes #198